### PR TITLE
Step3 지하철 노선에서 역 제외하는 인수 테스트 및 기능 작성

### DIFF
--- a/src/main/java/nextstep/subway/line/application/LineStationService.java
+++ b/src/main/java/nextstep/subway/line/application/LineStationService.java
@@ -3,6 +3,7 @@ package nextstep.subway.line.application;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
 import nextstep.subway.line.domain.LineStation;
+import nextstep.subway.line.domain.exceptions.NotRegisteredLineStationException;
 import nextstep.subway.line.dto.LineStationRequest;
 import nextstep.subway.line.dto.LineStationResponse;
 import nextstep.subway.station.domain.Station;
@@ -57,5 +58,16 @@ public class LineStationService {
         }
 
         return LineStation.createLineStation(station, preStation, createLineStationRequest.getDistance(), createLineStationRequest.getDuration());
+    }
+
+    @Transactional
+    public void excludeLineStation(Long lineId, Long stationId) {
+        Line line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new IllegalStateException("not found line : " + lineId));
+
+        Station station = stationRepository.findById(stationId)
+                .orElseThrow(() -> new IllegalStateException("not found line : " + lineId));
+
+        line.excludeLineStation(station);
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -1,8 +1,6 @@
 package nextstep.subway.line.domain;
 
 import nextstep.subway.config.BaseEntity;
-import nextstep.subway.line.domain.exceptions.LineStationAlreadyExist;
-import nextstep.subway.station.domain.Station;
 
 import javax.persistence.*;
 import java.time.LocalTime;

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -1,6 +1,7 @@
 package nextstep.subway.line.domain;
 
 import nextstep.subway.config.BaseEntity;
+import nextstep.subway.station.domain.Station;
 
 import javax.persistence.*;
 import java.time.LocalTime;
@@ -66,6 +67,10 @@ public class Line extends BaseEntity {
 
     public void registerLineStation(LineStation lineStation) {
         this.lineStations.registerLineStation(lineStation);
+    }
+
+    public void excludeLineStation(Station station) {
+        this.lineStations.excludeLineStation(station);
     }
 
     public List<LineStation> getLineStationsInOrder() {

--- a/src/main/java/nextstep/subway/line/domain/LineStations.java
+++ b/src/main/java/nextstep/subway/line/domain/LineStations.java
@@ -1,6 +1,6 @@
 package nextstep.subway.line.domain;
 
-import nextstep.subway.line.domain.exceptions.LineStationAlreadyExist;
+import nextstep.subway.line.domain.exceptions.LineStationAlreadyExistException;
 import nextstep.subway.station.domain.Station;
 
 import javax.persistence.*;
@@ -50,14 +50,14 @@ public class LineStations {
         return orderedLineStations;
     }
 
-    boolean hasStation(Station station) {
+    private boolean hasStation(Station station) {
         return this.lineStations.stream()
                 .anyMatch(lineStation -> lineStation.getStation() == station);
     }
 
     public void registerLineStation(LineStation lineStation) {
-        if (this.checkExistStation(lineStation.getStation())) {
-            throw new LineStationAlreadyExist("line station already exists : " + lineStation.getStation().getId());
+        if (this.hasStation(lineStation.getStation())) {
+            throw new LineStationAlreadyExistException("line station already exists : " + lineStation.getStation().getId());
         }
 
         lineStations.forEach(it -> {
@@ -70,9 +70,5 @@ public class LineStations {
         });
 
         this.lineStations.add(lineStation);
-    }
-
-    public boolean checkExistStation(Station station) {
-        return this.hasStation(station);
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/exceptions/AlreadyExistLineStationException.java
+++ b/src/main/java/nextstep/subway/line/domain/exceptions/AlreadyExistLineStationException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.line.domain.exceptions;
+
+public class AlreadyExistLineStationException extends RuntimeException {
+    public AlreadyExistLineStationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/domain/exceptions/LineStationAlreadyExist.java
+++ b/src/main/java/nextstep/subway/line/domain/exceptions/LineStationAlreadyExist.java
@@ -1,7 +1,0 @@
-package nextstep.subway.line.domain.exceptions;
-
-public class LineStationAlreadyExist extends RuntimeException {
-    public LineStationAlreadyExist(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/nextstep/subway/line/domain/exceptions/LineStationAlreadyExistException.java
+++ b/src/main/java/nextstep/subway/line/domain/exceptions/LineStationAlreadyExistException.java
@@ -1,7 +1,0 @@
-package nextstep.subway.line.domain.exceptions;
-
-public class LineStationAlreadyExistException extends RuntimeException {
-    public LineStationAlreadyExistException(String message) {
-        super(message);
-    }
-}

--- a/src/main/java/nextstep/subway/line/domain/exceptions/LineStationAlreadyExistException.java
+++ b/src/main/java/nextstep/subway/line/domain/exceptions/LineStationAlreadyExistException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.line.domain.exceptions;
+
+public class LineStationAlreadyExistException extends RuntimeException {
+    public LineStationAlreadyExistException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/domain/exceptions/NotRegisteredLineStationException.java
+++ b/src/main/java/nextstep/subway/line/domain/exceptions/NotRegisteredLineStationException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.line.domain.exceptions;
+
+public class NotRegisteredLineStationException extends RuntimeException {
+    public NotRegisteredLineStationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/ui/LineStationController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineStationController.java
@@ -1,12 +1,13 @@
 package nextstep.subway.line.ui;
 
 import nextstep.subway.line.application.LineStationService;
-import nextstep.subway.line.domain.exceptions.LineStationAlreadyExist;
+import nextstep.subway.line.domain.exceptions.LineStationAlreadyExistException;
 import nextstep.subway.line.dto.LineStationRequest;
 import nextstep.subway.line.dto.LineStationResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
@@ -32,11 +33,7 @@ public class LineStationController {
     public ResponseEntity<LineStationResponse> createLineStation(@PathVariable Long lineId, @RequestBody LineStationRequest createLineStationRequest) {
 
         LineStationResponse newLineStationResponse;
-        try {
-            newLineStationResponse = lineStationService.addLineStation(lineId, createLineStationRequest);
-        } catch (LineStationAlreadyExist e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(null);
-        }
+        newLineStationResponse = lineStationService.addLineStation(lineId, createLineStationRequest);
 
         URI location = ServletUriComponentsBuilder
                 .fromCurrentRequest()
@@ -45,5 +42,10 @@ public class LineStationController {
                 .toUri();
 
         return ResponseEntity.created(location).body(newLineStationResponse);
+    }
+
+    @ExceptionHandler(LineStationAlreadyExistException.class)
+    public final ResponseEntity handleException() {
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }
 }

--- a/src/main/java/nextstep/subway/line/ui/LineStationController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineStationController.java
@@ -1,7 +1,7 @@
 package nextstep.subway.line.ui;
 
 import nextstep.subway.line.application.LineStationService;
-import nextstep.subway.line.domain.exceptions.LineStationAlreadyExistException;
+import nextstep.subway.line.domain.exceptions.AlreadyExistLineStationException;
 import nextstep.subway.line.dto.LineStationRequest;
 import nextstep.subway.line.dto.LineStationResponse;
 import org.springframework.http.HttpStatus;
@@ -43,7 +43,15 @@ public class LineStationController {
         return ResponseEntity.created(location).body(newLineStationResponse);
     }
 
-    @ExceptionHandler(LineStationAlreadyExistException.class)
+    @DeleteMapping(path = "/{stationId}")
+    public ResponseEntity excludeStation(@PathVariable Long lineId, @PathVariable Long stationId) {
+        lineStationService.excludeLineStation(lineId, stationId);
+
+        return ResponseEntity.ok().build();
+    }
+
+
+    @ExceptionHandler(AlreadyExistLineStationException.class)
     public final ResponseEntity handleException() {
         return ResponseEntity.status(HttpStatus.CONFLICT).build();
     }

--- a/src/main/java/nextstep/subway/line/ui/LineStationController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineStationController.java
@@ -7,7 +7,6 @@ import nextstep.subway.line.dto.LineStationResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;

--- a/src/test/java/nextstep/subway/common/step/CommonAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/common/step/CommonAcceptanceStep.java
@@ -1,0 +1,15 @@
+package nextstep.subway.common.step;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.assertj.core.api.AbstractIntegerAssert;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommonAcceptanceStep {
+
+    public static void API_응답코드_검사(int actualStatus, HttpStatus expectedStatus) {
+        assertThat(actualStatus).isEqualTo(expectedStatus.value());
+    }
+}

--- a/src/test/java/nextstep/subway/line/acceptance/LineStationAddAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineStationAddAcceptanceTest.java
@@ -234,7 +234,7 @@ public class LineStationAddAcceptanceTest extends AcceptanceTest {
         LineResponse existLine = getLineResponse.as(LineResponse.class);
 
         지하철_노선의_역_갯수가_n개이다(existLine, 2);
-        지하철_노선에_역이_포함되지_않는다(existLine, stationId3);
+        지하철_노선에_역이_포함되지_않는다(existLine, stationId2);
 
         // 지하철 노선에 지하철역 순서 정렬됨
         지하철_노선이_정렬되어있다(existLine, Lists.newArrayList(1L, 3L));

--- a/src/test/java/nextstep/subway/line/acceptance/step/LineStationAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/acceptance/step/LineStationAcceptanceStep.java
@@ -1,11 +1,12 @@
 package nextstep.subway.line.acceptance.step;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.line.dto.LineStationResponse;
-import org.assertj.core.api.ListAssert;
+import nextstep.subway.station.dto.StationResponse;
 import org.springframework.http.MediaType;
 
 import java.time.LocalTime;
@@ -40,12 +41,28 @@ public class LineStationAcceptanceStep {
                 .containsExactlyElementsOf(orderedStationList);
     }
 
-    public static ListAssert<LineStationResponse> 지하철_노선의_갯수가_n개이다(LineResponse lineResponse, int n) {
-        return assertThat(lineResponse.getStations()).hasSize(n);
+    public static void 지하철_노선의_역_갯수가_n개이다(LineResponse lineResponse, int n) {
+        assertThat(lineResponse.getStations()).hasSize(n);
     }
 
     public static ExtractableResponse<Response> 지하철_노선_등록되어_있음(String name, String color) {
         return 지하철_노선을_생성한다(name, color, LocalTime.of(5, 30), LocalTime.of(23, 30), 5);
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선에_지하철역을_제외한다(Long lineId, Long stationId) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .delete("/lines/{lineId}/stations/{stationId}", lineId, stationId)
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
+
+    public static void 지하철_노선에_역이_포함되지_않는다(LineResponse lineResponse, Long stationId3) {
+        assertThat(lineResponse.getStations())
+                .extracting(LineStationResponse::getStation).extracting(StationResponse::getId)
+                .doesNotContain(stationId3);
     }
 
     private static Map<String, String> getLineStationRequestParameterMap(Long preStationId, Long stationId) {

--- a/src/test/java/nextstep/subway/line/acceptance/step/LineStationAcceptanceStep.java
+++ b/src/test/java/nextstep/subway/line/acceptance/step/LineStationAcceptanceStep.java
@@ -3,10 +3,18 @@ package nextstep.subway.line.acceptance.step;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.LineStationResponse;
+import org.assertj.core.api.ListAssert;
 import org.springframework.http.MediaType;
 
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+
+import static nextstep.subway.line.acceptance.step.LineAcceptanceStep.지하철_노선을_생성한다;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LineStationAcceptanceStep {
 
@@ -21,6 +29,23 @@ public class LineStationAcceptanceStep {
                 then().
                 log().all().
                 extract();
+    }
+
+    public static void 지하철_노선을_조회하는_요청이_성공(LineResponse lineResponse) {
+        assertThat(lineResponse).isNotNull();
+    }
+
+    public static void 지하철_노선이_정렬되어있다(LineResponse lineResponse, ArrayList<Long> orderedStationList) {
+        assertThat(lineResponse.getStations()).extracting(it -> it.getStation().getId())
+                .containsExactlyElementsOf(orderedStationList);
+    }
+
+    public static ListAssert<LineStationResponse> 지하철_노선의_갯수가_n개이다(LineResponse lineResponse, int n) {
+        return assertThat(lineResponse.getStations()).hasSize(n);
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_등록되어_있음(String name, String color) {
+        return 지하철_노선을_생성한다(name, color, LocalTime.of(5, 30), LocalTime.of(23, 30), 5);
     }
 
     private static Map<String, String> getLineStationRequestParameterMap(Long preStationId, Long stationId) {


### PR DESCRIPTION
더운 날씨에 리뷰어님들 항상 고생 많으십니다

step3까지 마무리했습니다~
인수테스트를 작성하면서 초기에는 테스트코드가 너무 복잡하고 알아보기 힘들었는데 지속해서 refactoring을 하다보니까 가독성도 좋고 인수 테스트의 항목을 문서처럼 읽을 수 있는 장점이 생기는 것 같습니다.
실무에서도 적극적으로 써볼 수 있도록 꾸준히 연습해봐야 할 것 같습니다~

---
별개인데 JPA 관련되서 궁금한 사항이 있어서 질문드립니다.
```java
Hibernate: 
    update
        line_station 
    set
        line_id=null 
    where
        line_id=? 
        and id=?
2020-07-09 11:35:16.975 TRACE 28585 --- [o-auto-1-exec-5] o.h.type.descriptor.sql.BasicBinder      : binding parameter [1] as [BIGINT] - [1]
2020-07-09 11:35:16.975 TRACE 28585 --- [o-auto-1-exec-5] o.h.type.descriptor.sql.BasicBinder      : binding parameter [2] as [BIGINT] - [2]
Hibernate: 
    delete 
    from
        line_station 
    where
        id=?
2020-07-09 11:35:16.976 TRACE 28585 --- [o-auto-1-exec-5] o.h.type.descriptor.sql.BasicBinder      : binding parameter [1] as [BIGINT] - [2]
```

ListStations에서 제외시키려는 LineStation을 list에서 제외하고 transcation이 종료되면 위의 쿼리가 실행되는것은 확인했습니다.
여기서 update와 delete 쿼리가 두번 날아가는데 delete 쿼리 1번으로 줄일 수 있는 방법은 없을까요?