### PR TITLE
Step2 - 인수 테스트 리팩터링

### DIFF
--- a/src/main/java/nextstep/subway/exceptions/AlreadyExistsEntityException.java
+++ b/src/main/java/nextstep/subway/exceptions/AlreadyExistsEntityException.java
@@ -1,0 +1,16 @@
+package nextstep.subway.exceptions;
+
+public class AlreadyExistsEntityException extends RuntimeException{
+
+    private final static String DEFAULT_EXCEPTION_MSG = "이미 존재하는 엔티티입니다.";
+    private final static String EXCEPTION_MSG = "%s은 이미 존재합니다.";
+
+
+    public AlreadyExistsEntityException() {
+        super(DEFAULT_EXCEPTION_MSG);
+    }
+
+    public AlreadyExistsEntityException(String param) {
+        super(String.format(EXCEPTION_MSG, param));
+    }
+}

--- a/src/main/java/nextstep/subway/exceptions/AlreadyExistsEntityException.java
+++ b/src/main/java/nextstep/subway/exceptions/AlreadyExistsEntityException.java
@@ -2,8 +2,8 @@ package nextstep.subway.exceptions;
 
 public class AlreadyExistsEntityException extends RuntimeException{
 
-    private final static String DEFAULT_EXCEPTION_MSG = "이미 존재하는 엔티티입니다.";
-    private final static String EXCEPTION_MSG = "%s은 이미 존재합니다.";
+    private static final String DEFAULT_EXCEPTION_MSG = "이미 존재하는 엔티티입니다.";
+    private static final String EXCEPTION_MSG = "%s은 이미 존재합니다.";
 
 
     public AlreadyExistsEntityException() {

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -37,9 +37,9 @@ public class LineService {
     }
 
     @Modifying
-    public void updateLine(Long id, Line target) {
+    public void updateLine(Long id, LineRequest lineRequest) {
         Line line = findById(id);
-        line.update(target);
+        line.update(lineRequest.toLine());
     }
 
     public void deleteLine(Long id) {

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -1,5 +1,6 @@
 package nextstep.subway.line.application;
 
+import nextstep.subway.exceptions.AlreadyExistsEntityException;
 import nextstep.subway.exceptions.NotFoundLineException;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class LineService {
+    public static final String LINE_EXCEPTION = "%s 노선";
     private final LineRepository lineRepository;
 
     public LineService(LineRepository lineRepository) {
@@ -22,6 +24,11 @@ public class LineService {
     }
 
     public LineResponse saveLine(LineRequest request) {
+        String requestName = request.getName();
+        if (lineRepository.existsByName(requestName)) {
+            throw new AlreadyExistsEntityException(String.format(LINE_EXCEPTION, requestName));
+        }
+
         Line persistLine = lineRepository.save(request.toLine());
         return LineResponse.of(persistLine);
     }

--- a/src/main/java/nextstep/subway/line/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/line/domain/LineRepository.java
@@ -3,4 +3,5 @@ package nextstep.subway.line.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
+    Boolean existsByName(String name);
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -38,8 +38,8 @@ public class LineController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity updateLine(@PathVariable Long id, @RequestBody Line target) {
-        lineService.updateLine(id, target);
+    public ResponseEntity updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+        lineService.updateLine(id, lineRequest);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -1,7 +1,7 @@
 package nextstep.subway.line.ui;
 
+import nextstep.subway.exceptions.AlreadyExistsEntityException;
 import nextstep.subway.line.application.LineService;
-import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +47,11 @@ public class LineController {
     public ResponseEntity deleteLine(@PathVariable Long id) {
         lineService.deleteLine(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(AlreadyExistsEntityException.class)
+    public ResponseEntity handleIllegalArgsException(AlreadyExistsEntityException e) {
+        return ResponseEntity.badRequest().build();
     }
 
 }

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -50,7 +50,7 @@ public class LineController {
     }
 
     @ExceptionHandler(AlreadyExistsEntityException.class)
-    public ResponseEntity handleIllegalArgsException(AlreadyExistsEntityException e) {
+    public ResponseEntity alreadyExistsEntityException(AlreadyExistsEntityException e) {
         return ResponseEntity.badRequest().build();
     }
 

--- a/src/test/java/nextstep/subway/line/Extractor.java
+++ b/src/test/java/nextstep/subway/line/Extractor.java
@@ -1,0 +1,46 @@
+package nextstep.subway.line;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.springframework.http.MediaType;
+
+public class Extractor {
+
+    public static ExtractableResponse<Response> get(String path) {
+
+        return when(restAssured()).get(path)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> post(String path, Object body) {
+        return when(restAssured()
+                .body(body)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)).post(path)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> put(String path, Object body) {
+        return when(restAssured()
+                .body(body)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)).put(path)
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> delete(String path) {
+        return when(restAssured()).delete(path)
+                .then().log().all().extract();
+    }
+
+    private static RequestSpecification when(RequestSpecification requestSpecification) {
+        return requestSpecification
+                .when();
+    }
+
+    private static RequestSpecification restAssured() {
+        return RestAssured
+                .given().log().all();
+    }
+
+}

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -113,45 +113,16 @@ public class LineAcceptanceTest extends AcceptanceTest {
         지하철_노선_삭제됨(response);
     }
 
-    private ExtractableResponse<Response> 지하철_노선_제거_요청(Long createdId) {
-        String path = 서비스_호출_경로_생성(createdId);
-        return RestAssured
-                .given().log().all()
-                .when().delete(path)
-                .then().log().all().extract();
+    @DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
+    @Test
+    void createStationWithDuplicateName() {
+        //given
+        지하철_노선_등록(신분당선);
+
+        // when
+        ExtractableResponse<Response> response = 지하철_노선_등록(신분당선);
+
+        // then
+        지하철역_생성_실패됨(response);
     }
-
-    private void 지하철_노선_삭제됨(ExtractableResponse<Response> response) {
-        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-    }
-
-
-    private ExtractableResponse<Response> 지하철_노선_등록(Map<String, String> params) {
-        return RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post(서비스_호출_경로_생성(null))
-                .then().log().all().extract();
-    }
-
-    private List<Long> 지하철_노선_아이디_추출(ExtractableResponse<Response>... list) {
-        return Stream.of(list)
-                .map(this::지하철_노선_아이디_추출)
-                .collect(Collectors.toList());
-    }
-
-    private Long 지하철_노선_아이디_추출(ExtractableResponse<Response> response) {
-        return Long.parseLong(response.header("Location").split("/")[2]);
-    }
-
-    private String 서비스_호출_경로_생성(Long createdId) {
-        String path = "/lines";
-        if (Objects.nonNull(createdId)) {
-            return path + "/" + createdId;
-        }
-
-        return path;
-    }
-
 }

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -1,21 +1,18 @@
 package nextstep.subway.line;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
-import nextstep.subway.line.domain.Line;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static nextstep.subway.line.LineStep.*;
 
 @DisplayName("지하철 노선 관련 기능")
 public class LineAcceptanceTest extends AcceptanceTest {
@@ -64,23 +61,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
         지하철_노선_목록_포함됨(createdLineIds, resultLineIds);
     }
 
-    private ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
-        return RestAssured
-                .given().log().all()
-                .when().get(서비스_호출_경로_생성(null))
-                .then().log().all().extract();
-
-    }
-
-    private List<Long> 지하철_노선_객체_리스트_반환(ExtractableResponse<Response> response) {
-        return response.jsonPath().getList(".", Line.class).stream()
-                .map(Line::getId)
-                .collect(Collectors.toList());
-    }
-
-    private ListAssert<Long> 지하철_노선_목록_포함됨(List<Long> createdLineIds, List<Long> resultLineIds) {
-        return Assertions.assertThat(resultLineIds).containsAll(createdLineIds);
-    }
 
     @DisplayName("지하철 노선을 조회한다.")
     @Test
@@ -95,10 +75,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         응답_결과_확인(response, HttpStatus.OK);
-    }
-
-    private void 응답_결과_확인(ExtractableResponse<Response> response, HttpStatus status) {
-        Assertions.assertThat(response.statusCode()).isEqualTo(status.value());
     }
 
 
@@ -122,36 +98,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
         지하철_노선_수정_확인(response2, params);
     }
 
-    private ExtractableResponse<Response> 지하철_노선_수정_요청(Long createdId, HashMap<String, String> params) {
-        String path = 서비스_호출_경로_생성(createdId);
-
-        return RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put(path)
-                .then().log().all().extract();
-    }
-
-    private void 지하철_노선_수정됨(ExtractableResponse<Response> response) {
-        Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    private void 지하철_노선_수정_확인(ExtractableResponse<Response> response, HashMap<String, String> params) {
-        Line line = response.jsonPath().getObject(".", Line.class);
-
-        Assertions.assertThat(line.getName()).isEqualTo(params.get("name"));
-        Assertions.assertThat(line.getColor()).isEqualTo(params.get("color"));
-    }
-
-    private ExtractableResponse<Response> 지하철_노선_조회_요청(Long id) {
-        String path = 서비스_호출_경로_생성(id);
-
-        return RestAssured
-                .given().log().all()
-                .when().get(path)
-                .then().log().all().extract();
-    }
 
     @DisplayName("지하철 노선을 제거한다.")
     @Test

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -179,15 +179,8 @@ public class LineAcceptanceTest extends AcceptanceTest {
         Assertions.assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
+
     private ExtractableResponse<Response> 지하철_노선_등록(Map<String, String> params) {
-        return 지하철_노선_등록(params.get("name"), params.get("color"));
-    }
-
-    private ExtractableResponse<Response> 지하철_노선_등록(String name, String color) {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", name);
-        params.put("color", color);
-
         return RestAssured
                 .given().log().all()
                 .body(params)

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -113,7 +113,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         지하철_노선_삭제됨(response);
     }
 
-    @DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
+    @DisplayName("기존에 존재하는 지하철 노선 이름으로 지하철 노선을 생성한다.")
     @Test
     void createStationWithDuplicateName() {
         //given
@@ -123,6 +123,6 @@ public class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철_노선_등록(신분당선);
 
         // then
-        지하철역_생성_실패됨(response);
+        지하철_노선_생성_실패됨(response);
     }
 }

--- a/src/test/java/nextstep/subway/line/LineStep.java
+++ b/src/test/java/nextstep/subway/line/LineStep.java
@@ -1,12 +1,11 @@
 package nextstep.subway.line;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.line.domain.Line;
+import nextstep.subway.utils.Extractor;
 import org.assertj.core.api.ListAssert;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -79,7 +78,7 @@ public class LineStep {
         return Long.parseLong(response.header("Location").split("/")[2]);
     }
 
-    public static void 지하철역_생성_실패됨(ExtractableResponse<Response> response) {
+    public static void 지하철_노선_생성_실패됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 

--- a/src/test/java/nextstep/subway/line/LineStep.java
+++ b/src/test/java/nextstep/subway/line/LineStep.java
@@ -1,0 +1,95 @@
+package nextstep.subway.line;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.line.domain.Line;
+import org.assertj.core.api.ListAssert;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LineStep {
+
+    public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
+        return Extractor.get(서비스_호출_경로_생성(null));
+
+    }
+
+    public static List<Long> 지하철_노선_객체_리스트_반환(ExtractableResponse<Response> response) {
+        return response.jsonPath().getList(".", Line.class).stream()
+                .map(Line::getId)
+                .collect(Collectors.toList());
+    }
+
+    public static ListAssert<Long> 지하철_노선_목록_포함됨(List<Long> createdLineIds, List<Long> resultLineIds) {
+        return assertThat(resultLineIds).containsAll(createdLineIds);
+    }
+
+    public static void 응답_결과_확인(ExtractableResponse<Response> response, HttpStatus status) {
+        assertThat(response.statusCode()).isEqualTo(status.value());
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_수정_요청(Long createdId, HashMap<String, String> params) {
+        return Extractor.put(서비스_호출_경로_생성(createdId), params);
+    }
+
+    public static void 지하철_노선_수정됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 지하철_노선_수정_확인(ExtractableResponse<Response> response, HashMap<String, String> params) {
+        Line line = response.jsonPath().getObject(".", Line.class);
+
+        assertThat(line.getName()).isEqualTo(params.get("name"));
+        assertThat(line.getColor()).isEqualTo(params.get("color"));
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청(Long id) {
+        return Extractor.get(서비스_호출_경로_생성(id));
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_제거_요청(Long createdId) {
+        return Extractor.delete(서비스_호출_경로_생성(createdId));
+    }
+
+    public static void 지하철_노선_삭제됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_등록(Map<String, String> params) {
+        return Extractor.post(서비스_호출_경로_생성(null), params);
+    }
+
+    public static List<Long> 지하철_노선_아이디_추출(ExtractableResponse<Response>... list) {
+        return Stream.of(list)
+                .map(LineStep::지하철_노선_아이디_추출)
+                .collect(Collectors.toList());
+    }
+
+    public static Long 지하철_노선_아이디_추출(ExtractableResponse<Response> response) {
+        return Long.parseLong(response.header("Location").split("/")[2]);
+    }
+
+    public static void 지하철역_생성_실패됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+
+    public static String 서비스_호출_경로_생성(Long createdId) {
+        String path = "/lines";
+        if (Objects.nonNull(createdId)) {
+            return path + "/" + createdId;
+        }
+
+        return path;
+    }
+}

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -1,137 +1,85 @@
 package nextstep.subway.station;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
-import nextstep.subway.station.dto.StationResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
+import static nextstep.subway.station.StationStep.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
+    private Map<String, String> 강남역;
+    private Map<String, String> 역삼역;
+
+    @BeforeEach
+    void setup() {
+        강남역 = new HashMap<String, String>() {{
+            put("name", "강남역");
+        }};
+        역삼역 = new HashMap<String, String>() {{
+            put("name", "역삼역");
+        }};
+    }
+
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStation() {
-        // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_생성_요청(강남역);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
+        응답_결과_확인(response, HttpStatus.CREATED);
+        지하철역_위치_확인(response);
     }
 
     @DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
     @Test
     void createStationWithDuplicateName() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse1 = 지하철역_생성_요청(강남역);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then()
-                .log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse2 = 지하철역_생성_요청(강남역);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        응답_결과_확인(createResponse2, HttpStatus.BAD_REQUEST);
     }
 
     @DisplayName("지하철역을 조회한다.")
     @Test
     void getStations() {
         /// given
-        Map<String, String> params1 = new HashMap<>();
-        params1.put("name", "강남역");
-        ExtractableResponse<Response> createResponse1 = RestAssured.given().log().all()
-                .body(params1)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
-
-        Map<String, String> params2 = new HashMap<>();
-        params2.put("name", "역삼역");
-        ExtractableResponse<Response> createResponse2 = RestAssured.given().log().all()
-                .body(params2)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse1 = 지하철역_생성_요청(강남역);
+        ExtractableResponse<Response> createResponse2 = 지하철역_생성_요청(역삼역);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_전체_조회_요청();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<Long> expectedLineIds = Arrays.asList(createResponse1, createResponse2).stream()
-                .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
-                .collect(Collectors.toList());
-        List<Long> resultLineIds = response.jsonPath().getList(".", StationResponse.class).stream()
-                .map(it -> it.getId())
-                .collect(Collectors.toList());
-        assertThat(resultLineIds).containsAll(expectedLineIds);
+        응답_결과_확인(response, HttpStatus.OK);
+        List<Long> expectedLineIds = 지하철역_위치_아이디_추출(createResponse1, createResponse2);
+        List<Long> resultLineIds = 지하철역_아이디_추출(response);
+        지하철역_목록_포함됨(expectedLineIds, resultLineIds);
     }
 
     @DisplayName("지하철역을 제거한다.")
     @Test
     void deleteStation() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse = 지하철역_생성_요청(강남역);
 
         // when
-        String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .delete(uri)
-                .then().log().all()
-                .extract();
+        Long targetId = 지하철역_위치_아이디_추출(createResponse);
+        ExtractableResponse<Response> response = 지하철역_제거_요청(targetId);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/src/test/java/nextstep/subway/station/StationStep.java
+++ b/src/test/java/nextstep/subway/station/StationStep.java
@@ -1,0 +1,69 @@
+package nextstep.subway.station;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.station.dto.StationResponse;
+import nextstep.subway.utils.Extractor;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StationStep {
+    private static final String DEFAULT_PATH = "/stations";
+    public static final String LOCATION = "Location";
+
+    public static ExtractableResponse<Response> 지하철역_생성_요청(Map<String, String> station) {
+        return Extractor.post(DEFAULT_PATH, station);
+    }
+
+    public static void 응답_결과_확인(ExtractableResponse<Response> response, HttpStatus status) {
+        assertThat(response.statusCode()).isEqualTo(status.value());
+    }
+
+    public static void 지하철역_위치_확인(ExtractableResponse<Response> response) {
+        assertThat(response.header(LOCATION)).isNotBlank();
+    }
+
+    public static ExtractableResponse<Response> 지하철역_전체_조회_요청() {
+        return Extractor.get(DEFAULT_PATH);
+    }
+
+    public static void 지하철역_목록_포함됨(List<Long> expectedLineIds, List<Long> resultLineIds) {
+        assertThat(resultLineIds).containsAll(expectedLineIds);
+    }
+
+    public static List<Long> 지하철역_아이디_추출(ExtractableResponse<Response> response) {
+        return response.jsonPath().getList(".", StationResponse.class).stream()
+                .map(StationResponse::getId)
+                .collect(Collectors.toList());
+    }
+
+    public static List<Long> 지하철역_위치_아이디_추출(ExtractableResponse<Response> ...createResponse) {
+        return Stream.of(createResponse)
+                .map(StationStep::지하철역_위치_아이디_추출)
+                .collect(Collectors.toList());
+    }
+
+    public static Long 지하철역_위치_아이디_추출(ExtractableResponse<Response> createResponse) {
+        return Long.parseLong(createResponse.header(LOCATION).split("/")[2]);
+    }
+
+    public static ExtractableResponse<Response> 지하철역_제거_요청(Long stationId) {
+
+        return Extractor.delete(서비스_호출_경로_생성(stationId));
+    }
+
+    public static String 서비스_호출_경로_생성(Long createdId) {
+        if (Objects.nonNull(createdId)) {
+            return DEFAULT_PATH + "/" + createdId;
+        }
+
+        return DEFAULT_PATH;
+    }
+}

--- a/src/test/java/nextstep/subway/utils/Extractor.java
+++ b/src/test/java/nextstep/subway/utils/Extractor.java
@@ -1,4 +1,4 @@
-package nextstep.subway.line;
+package nextstep.subway.utils;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;


### PR DESCRIPTION
1단계 피드백 적용및 2단계 요구사항 적용및 PR입니다! 😀

### 1단계 피드백 적용

- 지하철_노선_등록 메서드 하나로 압축
- updateLine API의 RequestBody를 Entity에서 DTO로 변경

### 2단계 요구사항

- LineAcceptanceTest 중복 메서드 통합
    1. 테스트에 필요한 api 요청 메서드들 LineStep 클래스로 분리
    2. 중복되는 RestAssured 요청 로직 Extractor 클래스로 분리
- 지하철 중복 등록 예외 테스트 케이스 생성
- 지하철 중복 등록 예외 테스트 구현
    1. Line 생성 서비스(createLine)에 생성 요청을 받은 라인이 중복되었는지 확인하는 로직 추가
    2. 라인이 중복되었을 경우 에러를 반환하는 로직 추가
    3. 라인중복 사용자 정의 예외 생성
    4. 에러 발생 핸들러 구현(LineController.alreadyExistsEntityException)
