### PR TITLE
[ghojeong / 고정완] Step2: 인수 테스트 리팩터링

### DIFF
--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -107,16 +107,17 @@ public class LineAcceptanceTest extends AcceptanceTest {
     void deleteLine() {
         // given
         // 지하철_노선_등록되어_있음
-        LineResponse lineResponse = 지하철_노선_생성_요청("1호선", "blue")
-                .as(LineResponse.class);
+        Long lineId = 지하철_노선_생성_요청("1호선", "blue")
+                .as(LineResponse.class)
+                .getId();
 
         // when
         // 지하철_노선_제거_요청
-        ExtractableResponse<Response> response = 지하철_노선_제거_요청(lineResponse.getId());
+        ExtractableResponse<Response> response = 지하철_노선_제거_요청(lineId);
 
         // then
-        // 지하철_노선_삭제됨
-        지하철_노선_삭제됨(response);
+        // 지하철_노선_제거됨
+        지하철_노선_제거됨(response);
     }
 
     private Map<String, String> createParam(String name, String color) {
@@ -210,7 +211,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
                 .then().log().all().extract();
     }
 
-    private void 지하철_노선_삭제됨(ExtractableResponse<Response> response) {
+    private void 지하철_노선_제거됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode())
                 .isEqualTo(NO_CONTENT.value());
     }

--- a/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/LineAcceptanceTest.java
@@ -10,11 +10,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.http.HttpStatus.*;
@@ -35,8 +35,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         // 지하철_노선_생성됨
-        assertThat(response.statusCode())
-                .isEqualTo(CREATED.value());
+        지하철_노선_생성됨(response);
     }
 
     @DisplayName("지하철 노선 목록을 조회한다.")
@@ -54,19 +53,10 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         // 지하철_노선_목록_응답됨
-        assertThat(linesResponse.statusCode())
-                .isEqualTo(OK.value());
+        지하철_노선_목록_응답됨(linesResponse);
         // 지하철_노선_목록_포함됨
-        List<Long> actualIds = linesResponse.jsonPath()
-                .getList(".", LineResponse.class)
-                .stream()
-                .map(LineResponse::getId)
-                .collect(Collectors.toList());
-        List<Long> expectedIds = Stream.of(line1Response, line2Response)
-                .map(response -> response.as(LineResponse.class))
-                .map(LineResponse::getId)
-                .collect(Collectors.toList());
-        assertThat(actualIds).containsAll(expectedIds);
+        지하철_노선_목록_포함됨(linesResponse,
+                Arrays.asList(line1Response, line2Response));
     }
 
 
@@ -75,25 +65,19 @@ public class LineAcceptanceTest extends AcceptanceTest {
     void getLine() {
         // given
         // 지하철_노선_등록되어_있음
-        LineResponse expectedLine = 지하철_노선_생성_요청("1호선", "blue")
-                .as(LineResponse.class);
+        ExtractableResponse<Response> expectedResponse = 지하철_노선_생성_요청("1호선", "blue");
         지하철_노선_생성_요청("2호선", "lightgreen");
 
         // when
         // 지하철_노선_조회_요청
-        Long lineId = expectedLine.getId();
-        LineResponse actualLine = 지하철_노선_조회_요청(lineId)
-                .as(LineResponse.class);
+        Long lineId = expectedResponse
+                .as(LineResponse.class)
+                .getId();
+        ExtractableResponse<Response> actualResponse = 지하철_노선_조회_요청(lineId);
 
         // then
         // 지하철_노선_응답됨
-        SoftAssertions softly = new SoftAssertions();
-        softly.assertThat(actualLine.getId())
-                .isEqualTo(expectedLine.getId());
-        softly.assertThat(actualLine.getName())
-                .isEqualTo(expectedLine.getName());
-        softly.assertThat(actualLine.getColor())
-                .isEqualTo(expectedLine.getColor());
+        지하철_노선_응답됨(actualResponse, expectedResponse);
     }
 
     @DisplayName("지하철 노선을 수정한다.")
@@ -101,25 +85,21 @@ public class LineAcceptanceTest extends AcceptanceTest {
     void updateLine() {
         // given
         // 지하철_노선_등록되어_있음
-        LineResponse lineResponse = 지하철_노선_생성_요청("1호선", "blue")
-                .as(LineResponse.class);
+        Long lineId = 지하철_노선_생성_요청("1호선", "blue")
+                .as(LineResponse.class)
+                .getId();
 
         // when
         // 지하철_노선_수정_요청
-        String expectedName = "9호선";
-        String expectedColor = "yellow";
-        LineResponse actualLine = 지하철_노선_수정_요청(
-                lineResponse.getId(),
-                createParam(expectedName, expectedColor)
-        ).as(LineResponse.class);
+        String name = "9호선";
+        String color = "yellow";
+        ExtractableResponse<Response> response = 지하철_노선_수정_요청(
+                lineId,
+                createParam(name, color));
 
         // then
         // 지하철_노선_수정됨
-        SoftAssertions softly = new SoftAssertions();
-        softly.assertThat(actualLine.getName())
-                .isEqualTo(expectedName);
-        softly.assertThat(actualLine.getColor())
-                .isEqualTo(expectedColor);
+        지하철_노선_수정됨(response, name, color);
     }
 
     @DisplayName("지하철 노선을 제거한다.")
@@ -136,8 +116,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         // 지하철_노선_삭제됨
-        assertThat(response.statusCode())
-                .isEqualTo(NO_CONTENT.value());
+        지하철_노선_삭제됨(response);
     }
 
     private Map<String, String> createParam(String name, String color) {
@@ -155,6 +134,11 @@ public class LineAcceptanceTest extends AcceptanceTest {
                 .then().log().all().extract();
     }
 
+    private void 지하철_노선_생성됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .isEqualTo(CREATED.value());
+    }
+
     private ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -162,11 +146,43 @@ public class LineAcceptanceTest extends AcceptanceTest {
                 .then().log().all().extract();
     }
 
+    private void 지하철_노선_목록_응답됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .isEqualTo(OK.value());
+    }
+
+    private void 지하철_노선_목록_포함됨(ExtractableResponse<Response> actualResponse,
+                               List<ExtractableResponse<Response>> responses) {
+        List<Long> actualIds = actualResponse.jsonPath()
+                .getList(".", LineResponse.class)
+                .stream()
+                .map(LineResponse::getId)
+                .collect(Collectors.toList());
+        List<Long> expectedIds = responses.stream()
+                .map(response -> response.as(LineResponse.class))
+                .map(LineResponse::getId)
+                .collect(Collectors.toList());
+        assertThat(actualIds).containsAll(expectedIds);
+    }
+
     private ExtractableResponse<Response> 지하철_노선_조회_요청(Long lineId) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get(PATH + "/{id}", lineId)
                 .then().log().all().extract();
+    }
+
+    private void 지하철_노선_응답됨(ExtractableResponse<Response> actualResponse, ExtractableResponse<Response> expectedResponse) {
+        LineResponse actualLine = actualResponse.as(LineResponse.class);
+        LineResponse expectedLine = expectedResponse.as(LineResponse.class);
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(actualLine.getId())
+                .isEqualTo(expectedLine.getId());
+        softly.assertThat(actualLine.getName())
+                .isEqualTo(expectedLine.getName());
+        softly.assertThat(actualLine.getColor())
+                .isEqualTo(expectedLine.getColor());
+        softly.assertAll();
     }
 
     private ExtractableResponse<Response> 지하철_노선_수정_요청(Long lineId, Map<String, String> params) {
@@ -177,10 +193,25 @@ public class LineAcceptanceTest extends AcceptanceTest {
                 .then().log().all().extract();
     }
 
+    private void 지하철_노선_수정됨(ExtractableResponse<Response> response, String expectedName, String expectedColor) {
+        LineResponse line = response.as(LineResponse.class);
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(line.getName())
+                .isEqualTo(expectedName);
+        softly.assertThat(line.getColor())
+                .isEqualTo(expectedColor);
+        softly.assertAll();
+    }
+
     private ExtractableResponse<Response> 지하철_노선_제거_요청(Long lineId) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().delete(PATH + "/{id}", lineId)
                 .then().log().all().extract();
+    }
+
+    private void 지하철_노선_삭제됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .isEqualTo(NO_CONTENT.value());
     }
 }

--- a/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/station/StationAcceptanceTest.java
@@ -5,6 +5,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.station.dto.StationResponse;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -17,123 +18,145 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.OK;
 
 @DisplayName("지하철역 관련 기능")
 public class StationAcceptanceTest extends AcceptanceTest {
+    private static final String PATH = "/stations";
+
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStation() {
-        // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        // 지하철_역_생성_요청
+        ExtractableResponse<Response> response = 지하철_역_생성_요청("강남역");
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
+        // 지하철_역_생성됨
+        지하철_역_생성됨(response);
     }
 
-    @DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성한다.")
+    @DisplayName("기존에 존재하는 지하철역 이름으로 지하철역을 생성하면 실패한다.")
     @Test
     void createStationWithDuplicateName() {
+        String name = "강남역";
+
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        // 지하철_역_등록되어_있음
+        지하철_역_등록되어_있음(name);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then()
-                .log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_역_생성_요청(name);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        지하철_역_생성_실패됨(response);
     }
 
-    @DisplayName("지하철역을 조회한다.")
+    @DisplayName("지하철 역 목록을 조회한다.")
     @Test
     void getStations() {
-        /// given
-        Map<String, String> params1 = new HashMap<>();
-        params1.put("name", "강남역");
-        ExtractableResponse<Response> createResponse1 = RestAssured.given().log().all()
-                .body(params1)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        String name1 = "강남역";
+        String name2 = "역삼역";
 
-        Map<String, String> params2 = new HashMap<>();
-        params2.put("name", "역삼역");
-        ExtractableResponse<Response> createResponse2 = RestAssured.given().log().all()
-                .body(params2)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        // given
+        // 지하철_역_등록되어_있음
+        ExtractableResponse<Response> createResponse1 = 지하철_역_생성_요청(name1);
+        ExtractableResponse<Response> createResponse2 = 지하철_역_생성_요청(name2);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
+        // 지하철_역_목록_조회_요청
+        ExtractableResponse<Response> response = 지하철_역_목록_조회_요청();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<Long> expectedLineIds = Arrays.asList(createResponse1, createResponse2).stream()
-                .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
-                .collect(Collectors.toList());
-        List<Long> resultLineIds = response.jsonPath().getList(".", StationResponse.class).stream()
-                .map(it -> it.getId())
-                .collect(Collectors.toList());
-        assertThat(resultLineIds).containsAll(expectedLineIds);
+        지하철_역_목록_응답됨(response,
+                Arrays.asList(createResponse1, createResponse2));
     }
 
     @DisplayName("지하철역을 제거한다.")
     @Test
     void deleteStation() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        // 지하철_역_등록되어_있음
+        ExtractableResponse<Response> createResponse = 지하철_역_생성_요청("강남역");
 
         // when
+        // 지하철_역_제거_요청
+        ExtractableResponse<Response> response = 지하철_역_제거_요청(createResponse);
+
+        // then
+        // 지하철_역_제거됨
+        지하철_역_제거됨(response);
+    }
+
+    private Map<String, String> createParam(String name) {
+        Map<String, String> param = new HashMap<>();
+        param.put("name", name);
+        return param;
+    }
+
+    private ExtractableResponse<Response> 지하철_역_생성_요청(String name) {
+        return RestAssured.given().log().all()
+                .body(createParam(name))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post(PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    private void 지하철_역_생성됨(ExtractableResponse<Response> response) {
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(response.statusCode())
+                .isEqualTo(HttpStatus.CREATED.value());
+        softly.assertThat(response.header("Location"))
+                .isNotBlank();
+        softly.assertAll();
+    }
+
+    private ExtractableResponse<Response> 지하철_역_등록되어_있음(String name) {
+        return 지하철_역_생성_요청(name);
+    }
+
+    private void 지하철_역_생성_실패됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    private ExtractableResponse<Response> 지하철_역_목록_조회_요청() {
+        return RestAssured.given().log().all()
+                .when().get(PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    private void 지하철_역_목록_응답됨(ExtractableResponse<Response> actualResponse, List<ExtractableResponse<Response>> expectedResponses) {
+        SoftAssertions softly = new SoftAssertions();
+        softly.assertThat(actualResponse.statusCode())
+                .isEqualTo(HttpStatus.OK.value());
+        List<Long> expectedLineIds = expectedResponses.stream()
+                .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
+                .collect(Collectors.toList());
+        List<Long> resultLineIds = actualResponse.jsonPath().getList(".", StationResponse.class).stream()
+                .map(StationResponse::getId)
+                .collect(Collectors.toList());
+        softly.assertThat(resultLineIds)
+                .containsAll(expectedLineIds);
+        softly.assertThat(actualResponse.statusCode())
+                .isEqualTo(OK.value());
+        softly.assertAll();
+    }
+
+    private ExtractableResponse<Response> 지하철_역_제거_요청(ExtractableResponse<Response> createResponse) {
         String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
+        return RestAssured.given().log().all()
                 .when()
                 .delete(uri)
                 .then().log().all()
                 .extract();
+    }
 
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    private void 지하철_역_제거됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode())
+                .isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 }


### PR DESCRIPTION
가이드를 따라하며, StationAcceptanceTest 를 리팩토링했습니다.

인수테스트를 해보니, 지하철 노선 이름 중복 금지 기능이 이미 구현되어 있는 듯 한데,
혹시 코드 상으로 어느 부분이 이름 중복 금지를 구현했는지 알 수 있을까요?

Station, StationController, StationService 코드를 살펴보아도,
중복 금지에 해당하는 로직이 어디에 나와있는지 잘 모르겠어서요.

설마 Station.java 에서 아래 부분이, 중복 생성을 금지해주는 코드인지 여쭈어봅니다.

```java
    @Column(unique = true)
    private String name;
```
