### PR TITLE
🚀 2단계 - 인수 테스트 리팩터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,6 @@ npm run dev
 ```
 ./gradlew bootRun
 ```
+
+### Step1 피드백
+엔티티를 update할 때, 인자를 직접 받아서 해당 상태를 변경하도록 한다.

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -43,7 +43,7 @@ public class LineService {
     @Modifying
     public void updateLine(Long id, LineRequest request) {
         Line line = findLineById(id);
-        line.update(new Line(request.getName(), request.getColor()));
+        line.update(request.getName(), request.getColor());
     }
 
     public void deleteLine(Long id) {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -31,8 +31,8 @@ public class Line extends BaseEntity {
         return color;
     }
 
-    public void update(Line line) {
-        name = line.name;
-        color = line.color;
+    public void update(String name, String color) {
+        this.name = name;
+        this.color = color;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,15 +1,13 @@
 package nextstep.subway.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 public class Line extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(unique = true)
     private String name;
     private String color;
 

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -1,15 +1,13 @@
 package nextstep.subway.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 public class Station extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(unique = true)
     private String name;
 
     public Station() {

--- a/src/main/java/nextstep/subway/exception/ExceptionResponse.java
+++ b/src/main/java/nextstep/subway/exception/ExceptionResponse.java
@@ -1,0 +1,17 @@
+package nextstep.subway.exception;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ExceptionResponse {
+    @ExceptionHandler(value = DataIntegrityViolationException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    public ResponseEntity<Void> handleDataIntegrityViolationException() {
+        return ResponseEntity.status(HttpStatus.CONFLICT).build();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -189,4 +189,36 @@ class LineAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    /**
+     * Scenario: 중복이름으로 지하철 노선 생성
+     * Given 지하철 노선 생성 요청 하고
+     * When 같은 이름으로 지하철 노선 생성을 요청 하면
+     * Then 지하철 노선 생성이 실패한다.
+     */
+    @DisplayName("지하철 노선 중복이름으로 생성")
+    @Test
+    void createLineWithDuplicateName() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "신분당선");
+        params.put("color", "bg-red-600");
+        ExtractableResponse<Response> createResponse = RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all().extract();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all().extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -115,4 +115,37 @@ class StationAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    /**
+     * Scenario: 중복이름으로 지하철역 생성
+     * Given 지하철역 생성을 요청하고
+     * When 같은 이름으로 지하철역 생성을 요청하면
+     * Then 지하철역 생성이 실패한다.
+     */
+    @DisplayName("지하철역 중복이름 생성")
+    @Test
+    void createStationWithDuplicateName() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "강남역");
+        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,21 +1,35 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static nextstep.subway.utils.RestAssuredRequest.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관리 기능")
 class StationAcceptanceTest extends AcceptanceTest {
+    private static final String STATIONS_PATH = "/stations";
+
+    private Map<String, String> 강남역;
+    private Map<String, String> 역삼역;
+
+    @BeforeEach
+    void initParam() {
+        강남역 = new HashMap<>();
+        강남역.put("name", "강남역");
+
+        역삼역 = new HashMap<>();
+        역삼역.put("name", "역삼역");
+    }
+
     /**
      * When 지하철역 생성을 요청 하면
      * Then 지하철역 생성이 성공한다.
@@ -23,22 +37,11 @@ class StationAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철역 생성")
     @Test
     void createStation() {
-        // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_생성_요청(강남역);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
+        지하철역_생성됨(response);
     }
 
     /**
@@ -51,38 +54,14 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void getStations() {
         /// given
-        String 강남역 = "강남역";
-        Map<String, String> params1 = new HashMap<>();
-        params1.put("name", 강남역);
-        ExtractableResponse<Response> createResponse1 = RestAssured.given().log().all()
-                .body(params1)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
-
-        String 역삼역 = "역삼역";
-        Map<String, String> params2 = new HashMap<>();
-        params2.put("name", 역삼역);
-        ExtractableResponse<Response> createResponse2 = RestAssured.given().log().all()
-                .body(params2)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        지하철역_등록되어_있음(강남역);
+        지하철역_등록되어_있음(역삼역);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_목록_조회_요청();
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<String> stationNames = response.jsonPath().getList("name");
-        assertThat(stationNames).contains(강남역, 역삼역);
+        // then
+        지하철역_목록_조회됨(response);
     }
 
     /**
@@ -94,26 +73,14 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse = 지하철역_등록되어_있음(강남역);
 
         // when
         String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .delete(uri)
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_삭제_요청(uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        지하철역_삭제됨(response);
     }
 
     /**
@@ -126,26 +93,54 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void createStationWithDuplicateName() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        지하철역_등록되어_있음(강남역);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_생성_요청(강남역);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+        지하철역_이름_중복됨(response);
+    }
+
+    private ExtractableResponse<Response> 지하철역_생성_요청(Map<String, String> params) {
+        return post(params, STATIONS_PATH);
+    }
+
+    private ExtractableResponse<Response> 지하철역_목록_조회_요청() {
+        return get(STATIONS_PATH);
+    }
+
+    private ExtractableResponse<Response> 지하철역_삭제_요청(String uri) {
+        return delete(uri);
+    }
+
+    private ExtractableResponse<Response> 지하철역_등록되어_있음(Map<String, String> params) {
+        ExtractableResponse<Response> response = 지하철역_생성_요청(params);
+        지하철역_생성됨(response);
+
+        return response;
+    }
+
+    private void 지하철역_생성됨(ExtractableResponse<Response> response) {
+        응답_요청_확인(response, HttpStatus.CREATED);
+        assertThat(response.header("Location")).isNotBlank();
+    }
+
+    private void 지하철역_목록_조회됨(ExtractableResponse<Response> response) {
+        응답_요청_확인(response, HttpStatus.OK);
+        List<String> stationNames = response.jsonPath().getList("name");
+        assertThat(stationNames).contains(강남역.get("name"), 역삼역.get("name"));
+    }
+
+    private void 지하철역_삭제됨(ExtractableResponse<Response> response) {
+        응답_요청_확인(response, HttpStatus.NO_CONTENT);
+    }
+
+    private void 지하철역_이름_중복됨(ExtractableResponse<Response> response) {
+        응답_요청_확인(response, HttpStatus.CONFLICT);
+    }
+
+    private void 응답_요청_확인(ExtractableResponse<Response> response, HttpStatus httpStatus) {
+        assertThat(response.statusCode()).isEqualTo(httpStatus.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -7,9 +7,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static nextstep.subway.utils.RestAssuredRequest.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,7 +63,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 지하철역_목록_조회_요청();
 
         // then
-        지하철역_목록_조회됨(response);
+        지하철역_목록_조회됨(response, 강남역, 역삼역);
     }
 
     /**
@@ -126,10 +128,13 @@ class StationAcceptanceTest extends AcceptanceTest {
         assertThat(response.header("Location")).isNotBlank();
     }
 
-    private void 지하철역_목록_조회됨(ExtractableResponse<Response> response) {
+    private void 지하철역_목록_조회됨(ExtractableResponse<Response> response, Map<String, String> ... params) {
         응답_요청_확인(response, HttpStatus.OK);
         List<String> stationNames = response.jsonPath().getList("name");
-        assertThat(stationNames).contains(강남역.get("name"), 역삼역.get("name"));
+        List<String> names = Arrays.stream(params)
+                .map(param -> param.get("name"))
+                .collect(Collectors.toList());
+        assertThat(stationNames).isEqualTo(names);
     }
 
     private void 지하철역_삭제됨(ExtractableResponse<Response> response) {

--- a/src/test/java/nextstep/subway/utils/RestAssuredRequest.java
+++ b/src/test/java/nextstep/subway/utils/RestAssuredRequest.java
@@ -1,0 +1,47 @@
+package nextstep.subway.utils;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class RestAssuredRequest {
+    public static ExtractableResponse<Response> post(Map<String, String> params, String path) {
+        return RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post(path)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> get(String uri) {
+        return RestAssured
+                .given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> put(String uri, Map<String, String> params) {
+        return RestAssured
+                .given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> delete(String uri) {
+        return RestAssured
+                .given().log().all()
+                .when().delete(uri)
+                .then().log().all()
+                .extract();
+    }
+}


### PR DESCRIPTION
안녕하세요~ 코드를 작성하는 일은 늘 고민이 생기네요...

몇 가지 궁금한 점이 있습니다. 😭

* 중복이름에 대한 처리
  처음엔 db에서 조회해서 save를 할까 생각을 했었습니다만, 동시에 접근하게 되면 문제가 생기겠다는 생각이 들었습니다.
  그래서 db단에서 처리하는게 좋다는 생각을 했고 unique를 이용했습니다.
  여기서 java단에서는 예외 처리를 어떻게 해야 하는가에 대한 고민이 들었습니다.
1. ConstraintViolationException이 발생하는데, 스프링에서 변환해주는 DataIntegrityViolationException으로 받아서 처리해도 되는가하는 질문입니다. (실무에서는 어떻게 하고 있을까요...?)
2. HttpStatus로 BadRequest, Conflict 정도가 떠올랐는데, 뭐로 하는게 더 어울릴까 하는 질문입니다.
~~~java
    @ExceptionHandler(value = DataIntegrityViolationException.class)
    @ResponseStatus(HttpStatus.CONFLICT)
    public ResponseEntity<Void> handleDataIntegrityViolationException() {
        return ResponseEntity.status(HttpStatus.CONFLICT).build();
    }
~~~

* 인수테스트 리팩터링에 관한 질문
1. CRUD 중복제거를 RestAssuredRequest.get, post, put, delete메서드로 분리하는 것이라고 생각을 했는데, 맞는가요?
2. 메서드 분리는 단순하게 중복되는 메서드를 공통 메서드로 분리하는 것이라고 생각한게 맞을까요?

3. post나 put요청에 사용되는 params를 어떻게 사용해야 하는가에 대한 질문입니다.
    - dto를 이용하면(LineRequest와 같은) 사용가이드 라인을 제공할 수 있지만, 의존성이 생긴다.
    - Map을 이용하면, 편리하지만, 어떤 값들이 존재해야하는지 알 수 없다.
    - 필요한 인자들을 직접 제공한다. given데이터를 관리하기가 어렵다.
~~~java
  private ExtractableResponse<Response> 지하철_노선_생성_요청(LineRequest requestParam) { ... }
  private ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> params) { ... }
  private ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) { ... }
~~~
4. `지하철_노선_목록_조회됨`, `지하철_노선_조회됨`, `지하철_노선_수정됨` 메서드가 값을 확인하는 부분에서 깔끔하지 않은 것 같은데, 리뷰어님이 값을 확인하시는 방법이 있을까요??

편하게 답해주시길 바라겠습니다! 감사합니다 😄
주말 잘 보내세요~👍