### PR TITLE
🚀 2단계 - 인수 테스트 리팩터링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'nextstep'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '1.8'
+sourceCompatibility = '11'
 
 repositories {
 	mavenCentral()

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -47,8 +47,6 @@ public class LineService {
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 노선입니다."));
 
         line.update(lineRequest.getName(), lineRequest.getColor());
-
-        lineRepository.save(line);
     }
 
     public void deleteLine(Long id) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -46,7 +46,7 @@ public class LineService {
                 .collect(Collectors.toList());
     }
 
-    //TODO: Transactional 추가할 것
+    @Transactional(readOnly = true)
     public LineResponse findLine(Long id) {
         Line line = lineRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 노선입니다."));

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -2,6 +2,7 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.exception.DuplicateException;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import org.springframework.stereotype.Service;
@@ -14,16 +15,26 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class LineService {
-    private LineRepository lineRepository;
+    private final LineRepository lineRepository;
 
     public LineService(LineRepository lineRepository) {
         this.lineRepository = lineRepository;
     }
 
-    public LineResponse saveLine(LineRequest request) {
-        Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        
+    public LineResponse saveLine(LineRequest lineRequest) {
+        validateDuplicatedLine(lineRequest);
+
+        Line line = lineRepository.save(new Line(lineRequest.getName(), lineRequest.getColor()));
+
         return LineResponse.of(line);
+    }
+
+    private void validateDuplicatedLine(LineRequest lineRequest) {
+        boolean existsLine = lineRepository.existsLineByName(lineRequest.getName());
+
+        if (existsLine) {
+            throw new DuplicateException("중복된 지하철 노선은 생성할 수 없습니다.");
+        }
     }
 
     @Transactional(readOnly = true)
@@ -35,6 +46,7 @@ public class LineService {
                 .collect(Collectors.toList());
     }
 
+    //TODO: Transactional 추가할 것
     public LineResponse findLine(Long id) {
         Line line = lineRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 노선입니다."));

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -21,7 +21,8 @@ public class StationService {
 
     public StationResponse saveStation(StationRequest stationRequest) {
         Station station = stationRepository.save(new Station(stationRequest.getName()));
-        return createStationResponse(station);
+
+        return StationResponse.of(station);
     }
 
     @Transactional(readOnly = true)
@@ -29,20 +30,11 @@ public class StationService {
         List<Station> stations = stationRepository.findAll();
 
         return stations.stream()
-                .map(this::createStationResponse)
+                .map(StationResponse::of)
                 .collect(Collectors.toList());
     }
 
     public void deleteStationById(Long id) {
         stationRepository.deleteById(id);
-    }
-
-    private StationResponse createStationResponse(Station station) {
-        return new StationResponse(
-                station.getId(),
-                station.getName(),
-                station.getCreatedDate(),
-                station.getModifiedDate()
-        );
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -2,6 +2,7 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.applicaion.exception.DuplicateException;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;
@@ -13,16 +14,26 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class StationService {
-    private StationRepository stationRepository;
+    private final StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;
     }
 
     public StationResponse saveStation(StationRequest stationRequest) {
+        validateDuplicatedStation(stationRequest);
+
         Station station = stationRepository.save(new Station(stationRequest.getName()));
 
         return StationResponse.of(station);
+    }
+
+    private void validateDuplicatedStation(StationRequest stationRequest) {
+        boolean existsStation = stationRepository.existsStationByName(stationRequest.getName());
+
+        if (existsStation) {
+            throw new DuplicateException("중복된 지하철 역은 생성할 수 없습니다.");
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/nextstep/subway/applicaion/dto/ErrorResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/ErrorResponse.java
@@ -1,0 +1,13 @@
+package nextstep.subway.applicaion.dto;
+
+public class ErrorResponse {
+    private final String message;
+
+    public ErrorResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
@@ -1,5 +1,7 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Station;
+
 import java.time.LocalDateTime;
 
 public class StationResponse {
@@ -30,4 +32,14 @@ public class StationResponse {
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
     }
+
+    public static StationResponse of(Station station) {
+        return new StationResponse(
+                station.getId(),
+                station.getName(),
+                station.getCreatedDate(),
+                station.getModifiedDate()
+        );
+    }
+
 }

--- a/src/main/java/nextstep/subway/applicaion/exception/DuplicateException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/DuplicateException.java
@@ -1,0 +1,15 @@
+package nextstep.subway.applicaion.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateException extends RuntimeException {
+    private final HttpStatus code = HttpStatus.CONFLICT;
+
+    public DuplicateException(String message) {
+        super(message);
+    }
+
+    public HttpStatus getCode() {
+        return code;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/GlobalExceptionHandler.java
@@ -1,0 +1,17 @@
+package nextstep.subway.applicaion.exception;
+
+import nextstep.subway.applicaion.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(DuplicateException.class)
+    public ResponseEntity<ErrorResponse> duplicateException(DuplicateException e) {
+
+        return new ResponseEntity<>(new ErrorResponse(e.getMessage()), HttpStatus.valueOf(e.getCode().value()));
+    }
+}

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -3,4 +3,5 @@ package nextstep.subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
+    boolean existsLineByName(String name);
 }

--- a/src/main/java/nextstep/subway/domain/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/StationRepository.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface StationRepository extends JpaRepository<Station, Long> {
     @Override
     List<Station> findAll();
+
+    boolean existsStationByName(String name);
 }

--- a/src/main/java/nextstep/subway/ui/StationController.java
+++ b/src/main/java/nextstep/subway/ui/StationController.java
@@ -20,6 +20,7 @@ public class StationController {
 
     @PostMapping("/stations")
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
+
         StationResponse station = stationService.saveStation(stationRequest);
         return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(station);
     }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -15,7 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
-    final String 아이디 = "id";
     final String 이름 = "name";
     final String 색상 = "color";
 
@@ -72,8 +71,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
 
         // when
-        final Long createdId = createResponse.jsonPath().getLong(아이디);
-        ExtractableResponse<Response> searchResponse = LineSteps.지하철_노선_조회_요청(createdId);
+        final String uri = createResponse.header("Location");
+        ExtractableResponse<Response> searchResponse = LineSteps.지하철_노선_조회_요청(uri);
 
         // then
         assertThat(searchResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -96,8 +95,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("color", "bg-blue-600");
 
         // when
-        final Long createdId = createResponse.jsonPath().getLong(아이디);
-        ExtractableResponse<Response> response = LineSteps.지하철_노선_수정_요청(createdId, params);
+        final String uri = createResponse.header("Location");
+        ExtractableResponse<Response> response = LineSteps.지하철_노선_수정_요청(uri, params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -115,8 +114,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
 
         // when
-        final Long createdId = createResponse.jsonPath().getLong(아이디);
-        ExtractableResponse<Response> response = LineSteps.지하철_노선_삭제_요청(createdId);
+        final String uri = createResponse.header("Location");
+        ExtractableResponse<Response> response = LineSteps.지하철_노선_삭제_요청(uri);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,6 +1,5 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.step.LineSteps;
@@ -117,11 +116,7 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // when
         final Long createdId = createResponse.jsonPath().getLong(아이디);
-
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .when().delete("/lines/{id}", createdId)
-                .then().log().all().extract();
+        ExtractableResponse<Response> response = LineSteps.지하철_노선_삭제_요청(createdId);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -37,6 +37,22 @@ class LineAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * When 중복된 지하철 노선 생성을 요청 하면
+     * Then 지하철 노선 생성이 실패한다.
+     */
+    @DisplayName("중복된 지하철 노선 생성")
+    @Test
+    void createDuplicateStation() {
+        LineSteps.지하철_노선_생성_요청(신분당선);
+
+        // given & when
+        ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
+
+        // then
+        assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
      * Given 지하철 노선 생성을 요청 하고
      * Given 새로운 지하철 노선 생성을 요청 하고
      * When 지하철 노선 목록 조회를 요청 하면

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -39,8 +39,7 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .log().all().extract();
 
         // then
-        assertThat(response.statusCode())
-                .isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         assertThat(response.header("Location")).isNotBlank();
     }
 
@@ -108,11 +107,11 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .then().log().all().extract();
 
         // when
-        final Long ID = createResponse.jsonPath().getLong("id");
+        final Long id = createResponse.jsonPath().getLong("id");
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
-                .when().get("/lines/{id}", ID)
+                .when().get("/lines/{id}", id)
                 .then().log().all().extract();
 
         // then
@@ -144,13 +143,13 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("color", "bg-blue-600");
 
         // when
-        final Long ID = createResponse.jsonPath().getLong("id");
+        final Long id = createResponse.jsonPath().getLong("id");
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put("/lines/{id}", ID)
+                .when().put("/lines/{id}", id)
                 .then().log().all().extract();
 
         // then
@@ -177,11 +176,11 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .then().log().all().extract();
 
         // when
-        final Long ID = createResponse.jsonPath().getLong("id");
+        final Long id = createResponse.jsonPath().getLong("id");
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
-                .when().delete("/lines/{id}", ID)
+                .when().delete("/lines/{id}", id)
                 .then().log().all().extract();
 
         // then

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -17,15 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
-    final Map<String, String> 신분당선 = Map.of(
-            "name", "신분당선",
-            "color", "bg-red-600"
-    );
+    final String 아이디 = "id";
+    final String 이름 = "name";
+    final String 색상 = "color";
 
-    final Map<String, String> 이호선 = Map.of(
-            "name", "2호선",
-            "color", "bg-green-600"
-    );
+    final Map<String, String> 신분당선 = Map.of(이름, "신분당선", 색상, "bg-red-600");
+    final Map<String, String> 이호선 = Map.of(이름, "2호선", 색상, "bg-green-600");
 
     /**
      * When 지하철 노선 생성을 요청 하면
@@ -56,17 +53,13 @@ class LineAcceptanceTest extends AcceptanceTest {
         LineSteps.지하철_노선_생성_요청(이호선);
 
         //when
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .when()
-                .get("/lines")
-                .then().log().all().extract();
+        ExtractableResponse<Response> searchResponse = LineSteps.지하철_노선_조회_요청();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(searchResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 
-        List<String> lineNames = response.jsonPath().getList("name");
-        assertThat(lineNames).contains(신분당선.get("name"), 이호선.get("name"));
+        List<String> lineNames = searchResponse.jsonPath().getList(이름);
+        assertThat(lineNames).contains(신분당선.get(이름), 이호선.get(이름));
     }
 
     /**
@@ -81,15 +74,11 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
 
         // when
-        final Long createdId = createResponse.jsonPath().getLong("id");
-
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .when().get("/lines/{id}", createdId)
-                .then().log().all().extract();
+        final Long createdId = createResponse.jsonPath().getLong(아이디);
+        ExtractableResponse<Response> searchResponse = LineSteps.지하철_노선_조회_요청(createdId);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(searchResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 
     }
 
@@ -109,7 +98,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("color", "bg-blue-600");
 
         // when
-        final Long createdId = createResponse.jsonPath().getLong("id");
+        final Long createdId = createResponse.jsonPath().getLong(아이디);
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
@@ -134,7 +123,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
 
         // when
-        final Long createdId = createResponse.jsonPath().getLong("id");
+        final Long createdId = createResponse.jsonPath().getLong(아이디);
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -7,7 +7,6 @@ import nextstep.subway.acceptance.step.LineSteps;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -99,13 +98,7 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // when
         final Long createdId = createResponse.jsonPath().getLong(아이디);
-
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put("/lines/{id}", createdId)
-                .then().log().all().extract();
+        ExtractableResponse<Response> response = LineSteps.지하철_노선_수정_요청(createdId, params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.acceptance.step.LineSteps;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -16,6 +17,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
+    final Map<String, String> 신분당선 = Map.of(
+            "name", "신분당선",
+            "color", "bg-red-600"
+    );
+
+    final Map<String, String> 이호선 = Map.of(
+            "name", "2호선",
+            "color", "bg-green-600"
+    );
+
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -23,20 +34,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선 생성")
     @Test
     void createLine() {
-        //given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "신분당선");
-        params.put("color", "bg-red-600");
-
-        //when
-        ExtractableResponse<Response> response = RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then()
-                .log().all().extract();
+        //given & when
+        ExtractableResponse<Response> response = LineSteps.지하철_노선_생성_요청(신분당선);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -52,26 +51,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선 목록 조회")
     @Test
     void getLines() {
-        //given
-        Map<String, String> params1 = new HashMap<>();
-        params1.put("name", "신분당선");
-        params1.put("color", "bg-red-600");
-        RestAssured
-                .given().log().all()
-                .body(params1)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all().extract();
-
-        Map<String, String> params2 = new HashMap<>();
-        params2.put("name", "2호선");
-        params2.put("color", "bg-green-600");
-        RestAssured
-                .given().log().all()
-                .body(params2)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all().extract();
+        //given & when
+        LineSteps.지하철_노선_생성_요청(신분당선);
+        LineSteps.지하철_노선_생성_요청(이호선);
 
         //when
         ExtractableResponse<Response> response = RestAssured
@@ -84,7 +66,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
 
         List<String> lineNames = response.jsonPath().getList("name");
-        assertThat(lineNames).contains("신분당선", "2호선");
+        assertThat(lineNames).contains(신분당선.get("name"), 이호선.get("name"));
     }
 
     /**
@@ -96,22 +78,14 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         //given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "신분당선");
-        params.put("color", "bg-red-600");
-        ExtractableResponse<Response> createResponse = RestAssured
-                .given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all().extract();
+        ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
 
         // when
-        final Long id = createResponse.jsonPath().getLong("id");
+        final Long createdId = createResponse.jsonPath().getLong("id");
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
-                .when().get("/lines/{id}", id)
+                .when().get("/lines/{id}", createdId)
                 .then().log().all().extract();
 
         // then
@@ -127,15 +101,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선 수정")
     @Test
     void updateLine() {
-        Map<String, String> createParams = new HashMap<>();
-        createParams.put("name", "신분당선");
-        createParams.put("color", "bg-red-600");
-        ExtractableResponse<Response> createResponse = RestAssured
-                .given().log().all()
-                .body(createParams)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all().extract();
+        ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
 
         //given
         Map<String, String> params = new HashMap<>();
@@ -143,13 +109,13 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("color", "bg-blue-600");
 
         // when
-        final Long id = createResponse.jsonPath().getLong("id");
+        final Long createdId = createResponse.jsonPath().getLong("id");
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put("/lines/{id}", id)
+                .when().put("/lines/{id}", createdId)
                 .then().log().all().extract();
 
         // then
@@ -165,22 +131,14 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         //given
-        Map<String, String> createParams = new HashMap<>();
-        createParams.put("name", "신분당선");
-        createParams.put("color", "bg-red-600");
-        ExtractableResponse<Response> createResponse = RestAssured
-                .given().log().all()
-                .body(createParams)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all().extract();
+        ExtractableResponse<Response> createResponse = LineSteps.지하철_노선_생성_요청(신분당선);
 
         // when
-        final Long id = createResponse.jsonPath().getLong("id");
+        final Long createdId = createResponse.jsonPath().getLong("id");
 
         ExtractableResponse<Response> response = RestAssured
                 .given().log().all()
-                .when().delete("/lines/{id}", id)
+                .when().delete("/lines/{id}", createdId)
                 .then().log().all().extract();
 
         // then

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -35,6 +35,22 @@ class StationAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * When 중복된 지하철역 생성을 요청 하면
+     * Then 지하철역 생성이 실패한다.
+     */
+    @DisplayName("중복된 지하철역 생성")
+    @Test
+    void createDuplicateStation() {
+        StationSteps.지하철_역_생성_요청(강남역);
+
+        // given & when
+        ExtractableResponse<Response> createResponse = StationSteps.지하철_역_생성_요청(강남역);
+
+        // then
+        assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
      * Given 지하철역 생성을 요청 하고
      * Given 새로운 지하철역 생성을 요청 하고
      * When 지하철역 목록 조회를 요청 하면

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -50,14 +50,10 @@ class StationAcceptanceTest extends AcceptanceTest {
         StationSteps.지하철_역_생성_요청(역삼역);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> searchResponse = StationSteps.지하철_역_조회_요청();
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<String> stationNames = response.jsonPath().getList(이름);
+        assertThat(searchResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+        List<String> stationNames = searchResponse.jsonPath().getList(이름);
         assertThat(stationNames).contains(강남역.get(이름), 역삼역.get(이름));
     }
 

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -35,10 +35,10 @@ class StationAcceptanceTest extends AcceptanceTest {
     }
 
     /**
-     * When 중복된 지하철역 생성을 요청 하면
+     * When 중복된 지하철 역 생성을 요청 하면
      * Then 지하철역 생성이 실패한다.
      */
-    @DisplayName("중복된 지하철역 생성")
+    @DisplayName("중복된 지하철 역 생성")
     @Test
     void createDuplicateStation() {
         StationSteps.지하철_역_생성_요청(강남역);

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,6 +1,5 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.acceptance.step.StationSteps;
@@ -15,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관리 기능")
 class StationAcceptanceTest extends AcceptanceTest {
-    final String 아이디 = "id";
     final String 이름 = "name";
 
     final Map<String, String> 강남역 = Map.of(이름, "강남역");
@@ -69,14 +67,10 @@ class StationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> createResponse = StationSteps.지하철_역_생성_요청(강남역);
 
         // when
-        String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .delete(uri)
-                .then().log().all()
-                .extract();
+        final String uri = createResponse.header("Location");
+        ExtractableResponse<Response> deleteResponse = StationSteps.지하철_역_삭제_요청(uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -3,10 +3,10 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.acceptance.step.StationSteps;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.List;
 import java.util.Map;
@@ -29,13 +29,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void createStation() {
         // given & when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(강남역)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = StationSteps.지하철_역_생성_요청(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -52,21 +46,8 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void getStations() {
         /// given
-        ExtractableResponse<Response> createResponse1 = RestAssured.given().log().all()
-                .body(강남역)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
-
-        ExtractableResponse<Response> createResponse2 = RestAssured.given().log().all()
-                .body(역삼역)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        StationSteps.지하철_역_생성_요청(강남역);
+        StationSteps.지하철_역_생성_요청(역삼역);
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -76,7 +57,7 @@ class StationAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<String> stationNames = response.jsonPath().getList("name");
+        List<String> stationNames = response.jsonPath().getList(이름);
         assertThat(stationNames).contains(강남역.get(이름), 역삼역.get(이름));
     }
 
@@ -89,13 +70,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(강남역)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse = StationSteps.지하철_역_생성_요청(강남역);
 
         // when
         String uri = createResponse.header("Location");

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -16,6 +15,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관리 기능")
 class StationAcceptanceTest extends AcceptanceTest {
+    final String 아이디 = "id";
+    final String 이름 = "name";
+
+    final Map<String, String> 강남역 = Map.of(이름, "강남역");
+    final Map<String, String> 역삼역 = Map.of(이름, "역삼역");
+
     /**
      * When 지하철역 생성을 요청 하면
      * Then 지하철역 생성이 성공한다.
@@ -23,13 +28,9 @@ class StationAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철역 생성")
     @Test
     void createStation() {
-        // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        // when
+        // given & when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
+                .body(강남역)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/stations")
@@ -51,22 +52,16 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void getStations() {
         /// given
-        String 강남역 = "강남역";
-        Map<String, String> params1 = new HashMap<>();
-        params1.put("name", 강남역);
         ExtractableResponse<Response> createResponse1 = RestAssured.given().log().all()
-                .body(params1)
+                .body(강남역)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/stations")
                 .then().log().all()
                 .extract();
 
-        String 역삼역 = "역삼역";
-        Map<String, String> params2 = new HashMap<>();
-        params2.put("name", 역삼역);
         ExtractableResponse<Response> createResponse2 = RestAssured.given().log().all()
-                .body(params2)
+                .body(역삼역)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/stations")
@@ -82,7 +77,7 @@ class StationAcceptanceTest extends AcceptanceTest {
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         List<String> stationNames = response.jsonPath().getList("name");
-        assertThat(stationNames).contains(강남역, 역삼역);
+        assertThat(stationNames).contains(강남역.get(이름), 역삼역.get(이름));
     }
 
     /**
@@ -94,10 +89,8 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
         ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(params)
+                .body(강남역)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/stations")

--- a/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
@@ -1,5 +1,23 @@
 package nextstep.subway.acceptance.step;
 
-public class LineStep {
-    
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class LineSteps {
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> 요청_노선) {
+
+        return RestAssured
+                .given().log().all()
+                .body(요청_노선)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then()
+                .log().all().extract();
+    }
+
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
@@ -8,6 +8,7 @@ import org.springframework.http.MediaType;
 import java.util.Map;
 
 public class LineSteps {
+
     public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> 요청_노선) {
 
         return RestAssured
@@ -18,6 +19,22 @@ public class LineSteps {
                 .post("/lines")
                 .then()
                 .log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청() {
+        return RestAssured
+                .given().log().all()
+                .when()
+                .get("/lines")
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청(Long id) {
+        return RestAssured
+                .given().log().all()
+                .when()
+                .get("/lines/{id}", id)
+                .then().log().all().extract();
     }
 
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
@@ -29,27 +29,27 @@ public class LineSteps {
                 .then().log().all().extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선_조회_요청(Long id) {
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청(String uri) {
         return RestAssured
                 .given().log().all()
                 .when()
-                .get("/lines/{id}", id)
+                .get(uri)
                 .then().log().all().extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선_수정_요청(Long id, Map<String, String> line) {
+    public static ExtractableResponse<Response> 지하철_노선_수정_요청(String uri, Map<String, String> line) {
         return RestAssured
                 .given().log().all()
                 .body(line)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put("/lines/{id}", id)
+                .when().put(uri)
                 .then().log().all().extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선_삭제_요청(Long id) {
+    public static ExtractableResponse<Response> 지하철_노선_삭제_요청(String uri) {
         return RestAssured
                 .given().log().all()
-                .when().delete("/lines/{id}", id)
+                .when().delete(uri)
                 .then().log().all().extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
@@ -45,4 +45,11 @@ public class LineSteps {
                 .when().put("/lines/{id}", id)
                 .then().log().all().extract();
     }
+
+    public static ExtractableResponse<Response> 지하철_노선_삭제_요청(Long id) {
+        return RestAssured
+                .given().log().all()
+                .when().delete("/lines/{id}", id)
+                .then().log().all().extract();
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
@@ -9,11 +9,11 @@ import java.util.Map;
 
 public class LineSteps {
 
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> 요청_노선) {
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(Map<String, String> line) {
 
         return RestAssured
                 .given().log().all()
-                .body(요청_노선)
+                .body(line)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/lines")
@@ -37,4 +37,12 @@ public class LineSteps {
                 .then().log().all().extract();
     }
 
+    public static ExtractableResponse<Response> 지하철_노선_수정_요청(Long id, Map<String, String> line) {
+        return RestAssured
+                .given().log().all()
+                .body(line)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put("/lines/{id}", id)
+                .then().log().all().extract();
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineSteps.java
@@ -1,0 +1,5 @@
+package nextstep.subway.acceptance.step;
+
+public class LineStep {
+    
+}

--- a/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
@@ -17,4 +17,12 @@ public class StationSteps {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 지하철_역_조회_요청() {
+        return RestAssured.given().log().all()
+                .when()
+                .get("/stations")
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
@@ -1,0 +1,2 @@
+package nextstep.subway.acceptance.step;public class StationSteps {
+}

--- a/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
@@ -1,2 +1,20 @@
-package nextstep.subway.acceptance.step;public class StationSteps {
+package nextstep.subway.acceptance.step;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class StationSteps {
+    public static ExtractableResponse<Response> 지하철_역_생성_요청(Map<String, String> station) {
+        return RestAssured.given().log().all()
+                .body(station)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationSteps.java
@@ -25,4 +25,12 @@ public class StationSteps {
                 .then().log().all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 지하철_역_삭제_요청(String uri) {
+        return RestAssured.given().log().all()
+                .when()
+                .delete(uri)
+                .then().log().all()
+                .extract();
+    }
 }


### PR DESCRIPTION
Step2를 진행하면서 테스트코드의 중복을 덜어내면서 테스트코드가 훨씬 더 명확해 진 것 같아서 집안 대청소를 한 느낌이었습니다...ㅋㅋㅋ

그리고 한글로 메서드나 변수명을 설정하는것을 선호하지 않아서 평소 전혀 사용하지 않았는데요. 이번에 말씀해주신 방식으로 진행해보니 확실히 가독성이 좋아지는것을 느꼈습니다!

실무에 적용해보고 싶을정도였습니다!

이번 PR은 커밋이 조금 잘게 처리되어있어서 _커밋단위로 리뷰해주시면 더 편하실 것 같아요 ☺️_

---

## 요구사항

- [x] 지하철역과 지하철 노선 이름 중복 금지 기능 추가
- [x] 새로운 기능 추가하면서 인수 테스트 리팩터링

---

## 궁금한점

1. 테스트 코드에서 Http StatusCode를 확인하는 라인도 공통화시키고 싶은 생각이 물씬 드는데요. (이런 저런 고민에 공통화하지는 못했습니다.. ㅠㅠ)
```java
assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
```
**위와 같은 테스트코드를 어떻게 공통화시키는게 Best일지 고민이 많이 됩니다.**

```java
assertThat(isEqualStatusCode(response.statusCode(), HttpStatus.NO_CONTENT.value()));
```
정도로밖에 생각이 들지 않는데, 공통화 시킨게 기존보다 훨씬 명확하지 않은것 같아서 고민입니다.
혹시 다른 좋은 방안이 있을지 궁금합니다!