### PR TITLE
Step2: 인수 테스트 리팩토링

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -58,7 +58,6 @@ public class LineService {
     public LineResponse updateLine(Long id, LineRequest lineRequest) {
         Line line = lineRepository.getById(id);
         line.modify(lineRequest.getName(), lineRequest.getColor());
-        lineRepository.save(line);
         return new LineResponse(
                 line.getId(),
                 line.getName(),

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -57,7 +57,8 @@ public class LineService {
 
     public LineResponse updateLine(Long id, LineRequest lineRequest) {
         Line line = lineRepository.getById(id);
-        line.modify(lineRequest.getName(), lineRequest.getColor());
+        line.setName(lineRequest.getName());
+        line.setColor(lineRequest.getColor());
         return new LineResponse(
                 line.getId(),
                 line.getName(),

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -22,7 +22,7 @@ public class LineService {
     public LineResponse saveLine(LineRequest request) {
         checkDuplication(request);
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        return new LineResponse(
+        return LineResponse.of(
                 line.getId(),
                 line.getName(),
                 line.getColor(),
@@ -41,7 +41,7 @@ public class LineService {
         List<Line> lines = lineRepository.findAll();
         return lines.stream()
                 .map( line ->
-                        new LineResponse(
+                        LineResponse.of(
                                 line.getId(),
                                 line.getName(),
                                 line.getColor(),
@@ -53,7 +53,7 @@ public class LineService {
 
     public LineResponse getLine(Long id) {
         Line line = lineRepository.getById(id);
-        return new LineResponse(
+        return LineResponse.of(
                 line.getId(),
                 line.getName(),
                 line.getColor(),

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -62,17 +62,10 @@ public class LineService {
         );
     }
 
-    public LineResponse updateLine(Long id, LineRequest lineRequest) {
+    public void updateLine(Long id, LineRequest lineRequest) {
         Line line = lineRepository.getById(id);
         line.setName(lineRequest.getName());
         line.setColor(lineRequest.getColor());
-        return new LineResponse(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                line.getCreatedDate(),
-                line.getModifiedDate()
-        );
     }
 
     public void deleteLine(Long id) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -20,6 +20,7 @@ public class LineService {
     }
 
     public LineResponse saveLine(LineRequest request) {
+        checkDuplication(request);
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
         return new LineResponse(
                 line.getId(),
@@ -28,6 +29,12 @@ public class LineService {
                 line.getCreatedDate(),
                 line.getModifiedDate()
         );
+    }
+
+    private void checkDuplication(LineRequest request) {
+        if (lineRepository.findByName(request.getName()).isPresent()) {
+            throw new IllegalArgumentException("[duplication]:name");
+        }
     }
 
     public List<LineResponse> findAllLines() {

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -20,8 +20,15 @@ public class StationService {
     }
 
     public StationResponse saveStation(StationRequest stationRequest) {
+        checkDuplication(stationRequest);
         Station station = stationRepository.save(new Station(stationRequest.getName()));
         return createStationResponse(station);
+    }
+
+    private void checkDuplication(StationRequest stationRequest) {
+        if (stationRepository.findByName(stationRequest.getName()).isPresent()) {
+            throw new IllegalArgumentException("[duplication]:name");
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -17,6 +17,10 @@ public class LineResponse {
         this.modifiedDate = modifiedDate;
     }
 
+    public static LineResponse of(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+        return new LineResponse(id, name, color, createdDate, modifiedDate);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -34,19 +34,14 @@ public class Line extends BaseEntity {
     }
 
     public void setName(String name) {
-        this.name = name;
+        if (name != null && !name.isEmpty()) {
+            this.name = name;
+        }
     }
 
     public void setColor(String color) {
-        this.color = color;
-    }
-
-    public void modify(String name, String color) {
-        if (name != null && !name.isEmpty()) {
-            this.setName(name);
-        }
         if (color != null && !color.isEmpty()) {
-            this.setColor(color);
+            this.color = color;
         }
     }
 }

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -2,5 +2,8 @@ package nextstep.subway.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LineRepository extends JpaRepository<Line, Long> {
+    Optional<Line> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/domain/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/StationRepository.java
@@ -3,8 +3,11 @@ package nextstep.subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
     @Override
     List<Station> findAll();
+
+    Optional<Station> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -45,8 +45,8 @@ public class LineController {
 
     @PutMapping("/{id}")
     public ResponseEntity<LineResponse> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
-        LineResponse line = lineService.updateLine(id, lineRequest);
-        return ResponseEntity.ok().body(line);
+        lineService.updateLine(id, lineRequest);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -14,6 +14,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
+
+    ExtractableResponse<Response> 지하철_노선_생성_API(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+    }
+
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -27,13 +38,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("color", "bg-red-900");
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_노선_생성_API(params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -53,22 +58,10 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("name", "GTX-A");
         params.put("color", "bg-red-900");
 
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        지하철_노선_생성_API(params);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_노선_생성_API(params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
@@ -92,21 +85,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         shinbundangLineParams.put("color", "bg-red-500");
 
         // given
-        RestAssured.given().log().all()
-                .body(gtxALineParams)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
-
-        RestAssured.given().log().all()
-                .body(shinbundangLineParams)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        지하철_노선_생성_API(gtxALineParams);
+        지하철_노선_생성_API(shinbundangLineParams);
 
         // when
         ExtractableResponse<Response> lines = RestAssured.given().log().all()
@@ -132,18 +112,12 @@ class LineAcceptanceTest extends AcceptanceTest {
      */
     @Test
     void 지하철_노선_조회_테스트() {
+        // given
         Map<String, String> params = new HashMap<>();
         params.put("name", "GTX-A");
         params.put("color", "bg-red-900");
 
-        // given
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        지하철_노선_생성_API(params);
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -176,13 +150,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("name", "GTX-A");
         params.put("color", "bg-red-900");
 
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        지하철_노선_생성_API(params);
 
         Map<String, String> updateParams = new HashMap<>();
         updateParams.put("color", "bg-red-800");
@@ -226,13 +194,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         params.put("name", "GTX-A");
         params.put("color", "bg-red-900");
 
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        지하철_노선_생성_API(params);
 
         // when
         ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -15,56 +15,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
 
-    ExtractableResponse<Response> 지하철_노선_생성_API(Map<String, String> params) {
-        return RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_전체_리스트_조회_API() {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/lines")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_단건_조회_API(Long id) {
-        return RestAssured.given().log().all()
-                .pathParam("id", id)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/lines/{id}")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_수정_API(Long id, Map<String, String> updateParams) {
-        return RestAssured.given().log().all()
-                .pathParam("id", id)
-                .body(updateParams)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .put("/lines/{id}")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_삭제_API(Long id) {
-        return RestAssured.given().log().all()
-                .pathParam("id", id)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .delete("/lines/{id}")
-                .then().log().all()
-                .extract();
-    }
-
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -216,5 +166,55 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    ExtractableResponse<Response> 지하철_노선_생성_API(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+    ExtractableResponse<Response> 지하철_노선_전체_리스트_조회_API() {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+    ExtractableResponse<Response> 지하철_노선_단건_조회_API(Long id) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
+    ExtractableResponse<Response> 지하철_노선_수정_API(Long id, Map<String, String> updateParams) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .body(updateParams)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
+    ExtractableResponse<Response> 지하철_노선_삭제_API(Long id) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/lines/{id}")
+                .then().log().all()
+                .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -20,6 +20,7 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Then 지하철 노선 생성이 성공한다.
      * @see nextstep.subway.ui.LineController#createLine
      */
+    @DisplayName("지하철 노선 생성 테스트")
     @Test
     void 지하철_노선_생성_테스트() {
         // given
@@ -39,6 +40,7 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Then 지하철 노선 생성이 실패한다.
      * @see nextstep.subway.ui.LineController#createLine
      */
+    @DisplayName("지하철 노선 이름 중복 생성 방지 테스트")
     @Test
     void 지하철_노선_이름_중복_생성_방지_테스트() {
         // given
@@ -62,6 +64,7 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Then 두 노선이 포함된 지하철 노선 목록을 응답받는다
      * @see nextstep.subway.ui.LineController#findAllLines()
      */
+    @DisplayName("지하철 노선 목록 조회 테스트")
     @Test
     void 지하철_노선_목록_조회_테스트() {
         // given
@@ -86,6 +89,7 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Then 생성한 지하철 노선을 응답받는다
      * @see nextstep.subway.ui.LineController#getLine
      */
+    @DisplayName("지하철 노선 조회 테스트")
     @Test
     void 지하철_노선_조회_테스트() {
         // given
@@ -111,6 +115,7 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Then 지하철 노선의 정보 수정은 성공한다.
      * @see nextstep.subway.ui.LineController#updateLine
      */
+    @DisplayName("지하철 노선 수정 테스트")
     @Test
     void 지하철_노선_수정_테스트() {
         // given
@@ -140,6 +145,7 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Then 생성한 지하철 노선 삭제가 성공한다.
      * @see nextstep.subway.ui.LineController#deleteLine
      */
+    @DisplayName("지하철 노선 삭제 테스트")
     @Test
     void 지하철_노선_삭제_테스트() {
         // given

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -44,6 +44,17 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    ExtractableResponse<Response> 지하철_노선_수정_API(Long id, Map<String, String> updateParams) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .body(updateParams)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -163,14 +174,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         updateParams.put("color", "bg-red-800");
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .pathParam("id", 1L)
-                .body(updateParams)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .put("/lines/{id}")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_노선_수정_API(1L, updateParams);
 
         // then
         ExtractableResponse<Response> updatedLine = 지하철_노선_단건_조회_API(1L);

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -34,6 +34,16 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    ExtractableResponse<Response> 지하철_노선_단건_조회_API(Long id) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -123,13 +133,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         지하철_노선_생성_API(params);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .pathParam("id", 1L)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/lines/{id}")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_노선_단건_조회_API(1L);
 
         // then
         String lineName = response.body().jsonPath().get("name").toString();
@@ -169,13 +173,7 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .extract();
 
         // then
-        ExtractableResponse<Response> updatedLine = RestAssured.given().log().all()
-                .pathParam("id", 1L)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/lines/{id}")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> updatedLine = 지하철_노선_단건_조회_API(1L);
         String lineName = updatedLine.body().jsonPath().get("name").toString();
         String lineColor = updatedLine.body().jsonPath().get("color").toString();
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -55,6 +55,16 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    ExtractableResponse<Response> 지하철_노선_삭제_API(Long id) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -202,13 +212,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         지하철_노선_생성_API(params);
 
         // when
-        ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()
-                .pathParam("id", 1L)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .delete("/lines/{id}")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> deleteResponse = 지하철_노선_삭제_API(1L);
 
         // then
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -23,9 +23,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_생성_테스트() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "GTX-A");
-        params.put("color", "bg-red-900");
+        Map<String, String> params = 파라미터_생성("GTX-A", "bg-red-900");
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_생성_API(params);
@@ -44,11 +42,11 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_이름_중복_생성_방지_테스트() {
         // given
-        지하철_노선_생성("GTX-A", "bg-red-900");
+        String 노선 = "GTX-A";
+        String 노선색 = "bg-red-900";
+        지하철_노선_생성(노선, 노선색);
 
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "GTX-A");
-        params.put("color", "bg-red-900");
+        Map<String, String> params = 파라미터_생성(노선, 노선색);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_생성_API(params);
@@ -67,6 +65,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_목록_조회_테스트() {
         // given
+        String 노선1 = "GTX-A";
+        String 노선2 = "신분당선";
         지하철_노선_생성("GTX-A", "bg-red-900");
         지하철_노선_생성("신분당선", "bg-red-500");
 
@@ -77,7 +77,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         List<String> lineNames = response.body().jsonPath().getList("name");
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(lineNames).contains("신분당선", "GTX-A");
+        assertThat(lineNames).contains(노선1, 노선2);
     }
 
     /**
@@ -152,10 +152,16 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
-    ExtractableResponse<Response> 지하철_노선_생성(String 노선, String 노선색) {
+    Map<String, String> 파라미터_생성(String 노선, String 노선색) {
         Map<String, String> params = new HashMap<>();
         params.put("name", 노선);
         params.put("color", 노선색);
+
+        return params;
+    }
+
+    ExtractableResponse<Response> 지하철_노선_생성(String 노선, String 노선색) {
+        Map<String, String> params = 파라미터_생성(노선, 노선색);
 
         return 지하철_노선_생성_API(params);
     }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -25,6 +25,15 @@ class LineAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    ExtractableResponse<Response> 지하철_노선_전체_리스트_조회_API() {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines")
+                .then().log().all()
+                .extract();
+    }
+
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -89,18 +98,12 @@ class LineAcceptanceTest extends AcceptanceTest {
         지하철_노선_생성_API(shinbundangLineParams);
 
         // when
-        ExtractableResponse<Response> lines = RestAssured.given().log().all()
-                .params(new HashMap<>())
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/lines")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_노선_전체_리스트_조회_API();
 
         // then
-        List<String> lineNames = lines.body().jsonPath().getList("name");
+        List<String> lineNames = response.body().jsonPath().getList("name");
 
-        assertThat(lines.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         assertThat(lineNames).contains("신분당선", "GTX-A");
     }
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -44,11 +44,11 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_이름_중복_생성_방지_테스트() {
         // given
+        지하철_노선_생성("GTX-A", "bg-red-900");
+
         Map<String, String> params = new HashMap<>();
         params.put("name", "GTX-A");
         params.put("color", "bg-red-900");
-
-        지하철_노선_생성_API(params);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_생성_API(params);
@@ -66,17 +66,9 @@ class LineAcceptanceTest extends AcceptanceTest {
      */
     @Test
     void 지하철_노선_목록_조회_테스트() {
-        Map<String, String> gtxALineParams = new HashMap<>();
-        gtxALineParams.put("name", "GTX-A");
-        gtxALineParams.put("color", "bg-red-900");
-
-        Map<String, String> shinbundangLineParams = new HashMap<>();
-        shinbundangLineParams.put("name", "신분당선");
-        shinbundangLineParams.put("color", "bg-red-500");
-
         // given
-        지하철_노선_생성_API(gtxALineParams);
-        지하철_노선_생성_API(shinbundangLineParams);
+        지하철_노선_생성("GTX-A", "bg-red-900");
+        지하철_노선_생성("신분당선", "bg-red-500");
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_전체_리스트_조회_API();
@@ -97,11 +89,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_조회_테스트() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "GTX-A");
-        params.put("color", "bg-red-900");
-
-        지하철_노선_생성_API(params);
+        String 노선  = "GTX-A";
+        String 노선색  = "bg-red-900";
+        지하철_노선_생성(노선, 노선색);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_단건_조회_API(1L);
@@ -111,8 +101,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         String lineColor = response.body().jsonPath().get("color").toString();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(lineName).isEqualTo("GTX-A");
-        assertThat(lineColor).isEqualTo("bg-red-900");
+        assertThat(lineName).isEqualTo(노선);
+        assertThat(lineColor).isEqualTo(노선색);
     }
 
     /**
@@ -124,14 +114,12 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_수정_테스트() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "GTX-A");
-        params.put("color", "bg-red-900");
-
-        지하철_노선_생성_API(params);
+        String 노선  = "GTX-A";
+        String 노선색  = "bg-red-800";
+        지하철_노선_생성(노선, "bg-red-900");
 
         Map<String, String> updateParams = new HashMap<>();
-        updateParams.put("color", "bg-red-800");
+        updateParams.put("color", 노선색);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_수정_API(1L, updateParams);
@@ -142,8 +130,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         String lineColor = updatedLine.body().jsonPath().get("color").toString();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(lineName).isEqualTo("GTX-A");
-        assertThat(lineColor).isEqualTo("bg-red-800");
+        assertThat(lineName).isEqualTo(노선);
+        assertThat(lineColor).isEqualTo(노선색);
     }
 
     /**
@@ -155,17 +143,21 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_삭제_테스트() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "GTX-A");
-        params.put("color", "bg-red-900");
-
-        지하철_노선_생성_API(params);
+        지하철_노선_생성("GTX-A", "bg-red-900");
 
         // when
         ExtractableResponse<Response> deleteResponse = 지하철_노선_삭제_API(1L);
 
         // then
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    ExtractableResponse<Response> 지하철_노선_생성(String 노선, String 노선색) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", 노선);
+        params.put("color", 노선색);
+
+        return 지하철_노선_생성_API(params);
     }
 
     ExtractableResponse<Response> 지하철_노선_생성_API(Map<String, String> params) {

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -41,6 +41,40 @@ class LineAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * Given 지하철역 생성을 요청 하고
+     * When 같은 이름으로 지하철역 생성을 요청 하면
+     * Then 지하철역 생성이 실패한다.
+     * @see nextstep.subway.ui.LineController#createLine
+     */
+    @Test
+    void 지하철_노선_이름_중복_생성_방지_테스트() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "GTX-A");
+        params.put("color", "bg-red-900");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    /**
      * Given 지하철 노선 생성을 요청 하고
      * Given 새로운 지하철 노선 생성을 요청 하고
      * When 지하철 노선 목록 조회를 요청 하면

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -41,9 +41,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     }
 
     /**
-     * Given 지하철역 생성을 요청 하고
-     * When 같은 이름으로 지하철역 생성을 요청 하면
-     * Then 지하철역 생성이 실패한다.
+     * Given 지하철 노선 생성을 요청 하고
+     * When 같은 이름으로 지하철 노선 생성을 요청 하면
+     * Then 지하철 노선 생성이 실패한다.
      * @see nextstep.subway.ui.LineController#createLine
      */
     @Test

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -28,13 +28,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         params.put("name", "강남역");
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_생성_API(params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -53,13 +47,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         Map<String, String> params = new HashMap<>();
         params.put("name", "강남역");
 
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        지하철역_생성_API(params);
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -87,24 +75,12 @@ class StationAcceptanceTest extends AcceptanceTest {
         String 강남역 = "강남역";
         Map<String, String> params1 = new HashMap<>();
         params1.put("name", 강남역);
-        ExtractableResponse<Response> createResponse1 = RestAssured.given().log().all()
-                .body(params1)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        지하철역_생성_API(params1);
 
         String 역삼역 = "역삼역";
         Map<String, String> params2 = new HashMap<>();
         params2.put("name", 역삼역);
-        ExtractableResponse<Response> createResponse2 = RestAssured.given().log().all()
-                .body(params2)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        지하철역_생성_API(params2);
 
         // when
         ExtractableResponse<Response> response = RestAssured.given().log().all()
@@ -129,13 +105,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         // given
         Map<String, String> params = new HashMap<>();
         params.put("name", "강남역");
-        ExtractableResponse<Response> createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> createResponse = 지하철역_생성_API(params);
 
         // when
         String uri = createResponse.header("Location");
@@ -147,5 +117,15 @@ class StationAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -43,11 +43,11 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철역_이름_중복_생성_방지_테스트() {
         // given
-        Map<String, String> params = 파라미터_생성("강남역");
-        지하철역_생성_API(params);
+        String 강남역 = "강남역";
+        지하철역_생성(강남역);
 
         // when
-        ExtractableResponse<Response> response = 지하철역_생성_API(params);
+        ExtractableResponse<Response> response = 지하철역_생성(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
@@ -64,12 +64,10 @@ class StationAcceptanceTest extends AcceptanceTest {
     void getStations() {
         /// given
         String 강남역 = "강남역";
-        Map<String, String> params1 = 파라미터_생성(강남역);
-        지하철역_생성_API(params1);
+        지하철역_생성(강남역);
 
         String 역삼역 = "역삼역";
-        Map<String, String> params2 = 파라미터_생성(역삼역);
-        지하철역_생성_API(params2);
+        지하철역_생성(역삼역);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_전체_리스트_조회_API();
@@ -88,8 +86,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        Map<String, String> params = 파라미터_생성("강남역");
-        ExtractableResponse<Response> createResponse = 지하철역_생성_API(params);
+        ExtractableResponse<Response> createResponse = 지하철역_생성("강남역");
 
         // when
         String uri = createResponse.header("Location");
@@ -104,6 +101,12 @@ class StationAcceptanceTest extends AcceptanceTest {
         params.put("name", 지하철역명);
 
         return params;
+    }
+
+    ExtractableResponse<Response> 지하철역_생성(String 지하철역명) {
+        Map<String, String> params = 파라미터_생성(지하철역명);
+
+        return 지하철역_생성_API(params);
     }
 
     ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -24,8 +24,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void createStation() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
+        Map<String, String> params = 파라미터_생성("강남역");
 
         // when
         ExtractableResponse<Response> response = 지하철역_생성_API(params);
@@ -44,9 +43,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철역_이름_중복_생성_방지_테스트() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
+        Map<String, String> params = 파라미터_생성("강남역");
         지하철역_생성_API(params);
 
         // when
@@ -67,13 +64,11 @@ class StationAcceptanceTest extends AcceptanceTest {
     void getStations() {
         /// given
         String 강남역 = "강남역";
-        Map<String, String> params1 = new HashMap<>();
-        params1.put("name", 강남역);
+        Map<String, String> params1 = 파라미터_생성(강남역);
         지하철역_생성_API(params1);
 
         String 역삼역 = "역삼역";
-        Map<String, String> params2 = new HashMap<>();
-        params2.put("name", 역삼역);
+        Map<String, String> params2 = 파라미터_생성(역삼역);
         지하철역_생성_API(params2);
 
         // when
@@ -93,8 +88,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
+        Map<String, String> params = 파라미터_생성("강남역");
         ExtractableResponse<Response> createResponse = 지하철역_생성_API(params);
 
         // when
@@ -103,6 +97,13 @@ class StationAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    Map<String, String> 파라미터_생성(String 지하철역명) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", 지하철역명);
+
+        return params;
     }
 
     ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -40,6 +40,7 @@ class StationAcceptanceTest extends AcceptanceTest {
      * Then 지하철역 생성이 실패한다.
      * @see nextstep.subway.ui.StationController#createStation
      */
+    @DisplayName("지하철역 이름 중복 생성 방지 테스트")
     @Test
     void 지하철역_이름_중복_생성_방지_테스트() {
         // given

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -43,6 +43,39 @@ class StationAcceptanceTest extends AcceptanceTest {
 
     /**
      * Given 지하철역 생성을 요청 하고
+     * When 같은 이름으로 지하철역 생성을 요청 하면
+     * Then 지하철역 생성이 실패한다.
+     * @see nextstep.subway.ui.StationController#createStation
+     */
+    @Test
+    void 지하철역_이름_중복_생성_방지_테스트() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "강남역");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    /**
+     * Given 지하철역 생성을 요청 하고
      * Given 새로운 지하철역 생성을 요청 하고
      * When 지하철역 목록 조회를 요청 하면
      * Then 두 지하철역이 포함된 지하철역 목록을 응답받는다

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -50,13 +50,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         지하철역_생성_API(params);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철역_생성_API(params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -99,11 +99,7 @@ class StationAcceptanceTest extends AcceptanceTest {
 
         // when
         String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .delete(uri)
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_노선_삭제_API(uri);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -123,6 +119,14 @@ class StationAcceptanceTest extends AcceptanceTest {
         return RestAssured.given().log().all()
                 .when()
                 .get("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    ExtractableResponse<Response> 지하철_노선_삭제_API(String uri) {
+        return RestAssured.given().log().all()
+                .when()
+                .delete(uri)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -77,11 +77,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         지하철역_생성_API(params2);
 
         // when
-        ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_노선_전체_리스트_조회_API();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         List<String> stationNames = response.jsonPath().getList("name");
@@ -119,6 +115,14 @@ class StationAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    ExtractableResponse<Response> 지하철_노선_전체_리스트_조회_API() {
+        return RestAssured.given().log().all()
+                .when()
+                .get("/stations")
                 .then().log().all()
                 .extract();
     }


### PR DESCRIPTION
[요구 사항]

지하철역과 지하철 노선 이름 중복 금지 기능 추가
새로운 기능 추가하면서 인수 테스트 리팩터링

[질문 사항]
테스트코드의 중복을 줄이면서 파라미터_생성 메소드를 만들었습니다.
 생성 파라미터와 수정 파라미터의 차이 때문에 if문으로 분기를 만들려했으나, 테스트코드를 위한 메소드륾 만들고 분기를 생성하면, 테스트를 위한 테스트를 또 해야하는 딜레마에  빠지는것 같은데요....ㅎㅎㅎ
테스트코드를 위한 테스트코드를 만드는 작업도 있을까요...????

[파라미터_생성](https://github.com/next-step/atdd-subway-map/pull/213/files#diff-711a8bc4d7e61641b908f7abc563a1e3593627b3d2c9bd30ebb213d97a7f3741R161-R167)메소드

[updateParam](https://github.com/next-step/atdd-subway-map/pull/213/files#diff-711a8bc4d7e61641b908f7abc563a1e3593627b3d2c9bd30ebb213d97a7f3741R126-R127)변수