### PR TITLE
1주차 2단계 - 인수 테스트 리팩터링

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -29,13 +29,7 @@ public class LineService {
         }
 
         Line line = lineRepository.save(new Line(requestName, requestColor));
-        return new LineResponse(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                line.getCreatedDate(),
-                line.getModifiedDate()
-        );
+        return LineResponse.of(line);
     }
 
     public void deleteLineById(Long id) {
@@ -47,7 +41,7 @@ public class LineService {
         var line = lineRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + id));
 
-        return createLineResponse(line);
+        return LineResponse.of(line);
     }
 
     @Transactional(readOnly = true)
@@ -55,7 +49,7 @@ public class LineService {
         var lines = lineRepository.findAll();
 
         return lines.stream()
-                .map(this::createLineResponse)
+                .map(LineResponse::of)
                 .collect(Collectors.toList());
     }
 
@@ -64,21 +58,11 @@ public class LineService {
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + id));
         line.update(lineRequest.getName(), lineRequest.getColor());
 
-        return createLineResponse(line);
+        return LineResponse.of(line);
     }
 
     private boolean isLineNamePresent(String lineName) {
         return lineRepository.findByName(lineName)
                 .isPresent();
-    }
-
-    private LineResponse createLineResponse(Line line) {
-        return new LineResponse(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                line.getCreatedDate(),
-                line.getModifiedDate()
-        );
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -2,6 +2,7 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.common.exception.DuplicateAttributeException;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,14 @@ public class LineService {
     }
 
     public LineResponse saveLine(LineRequest request) {
-        Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
+        var requestName = request.getName();
+        var requestColor = request.getColor();
+
+        if (isLineNamePresent(requestName)) {
+            throw new DuplicateAttributeException("이미 존재하는 노선 명: " + requestName);
+        }
+
+        Line line = lineRepository.save(new Line(requestName, requestColor));
         return new LineResponse(
                 line.getId(),
                 line.getName(),
@@ -57,6 +65,11 @@ public class LineService {
         line.update(lineRequest.getName(), lineRequest.getColor());
 
         return createLineResponse(line);
+    }
+
+    private boolean isLineNamePresent(String lineName) {
+        return lineRepository.findByName(lineName)
+                .isPresent();
     }
 
     private LineResponse createLineResponse(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -2,6 +2,7 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.common.exception.DuplicateAttributeException;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,12 @@ public class StationService {
     }
 
     public StationResponse saveStation(StationRequest stationRequest) {
-        Station station = stationRepository.save(new Station(stationRequest.getName()));
+        var name = stationRequest.getName();
+        if (isStationNamePresent(name)) {
+            throw new DuplicateAttributeException("이미 존재하는 역명: " + name);
+        }
+
+        Station station = stationRepository.save(new Station(name));
         return createStationResponse(station);
     }
 
@@ -35,6 +41,11 @@ public class StationService {
 
     public void deleteStationById(Long id) {
         stationRepository.deleteById(id);
+    }
+
+    private boolean isStationNamePresent(String stationName) {
+        return stationRepository.findByName(stationName)
+                .isPresent();
     }
 
     private StationResponse createStationResponse(Station station) {

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -27,7 +27,7 @@ public class StationService {
         }
 
         Station station = stationRepository.save(new Station(name));
-        return createStationResponse(station);
+        return StationResponse.of(station);
     }
 
     @Transactional(readOnly = true)
@@ -35,7 +35,7 @@ public class StationService {
         List<Station> stations = stationRepository.findAll();
 
         return stations.stream()
-                .map(this::createStationResponse)
+                .map(StationResponse::of)
                 .collect(Collectors.toList());
     }
 
@@ -48,12 +48,4 @@ public class StationService {
                 .isPresent();
     }
 
-    private StationResponse createStationResponse(Station station) {
-        return new StationResponse(
-                station.getId(),
-                station.getName(),
-                station.getCreatedDate(),
-                station.getModifiedDate()
-        );
-    }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,5 +1,7 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Line;
+
 import java.time.LocalDateTime;
 
 public class LineResponse {
@@ -35,5 +37,15 @@ public class LineResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public static LineResponse of(Line line) {
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                line.getCreatedDate(),
+                line.getModifiedDate()
+        );
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
@@ -1,5 +1,7 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Station;
+
 import java.time.LocalDateTime;
 
 public class StationResponse {
@@ -29,5 +31,14 @@ public class StationResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public static StationResponse of(Station station) {
+        return new StationResponse(
+                station.getId(),
+                station.getName(),
+                station.getCreatedDate(),
+                station.getModifiedDate()
+        );
     }
 }

--- a/src/main/java/nextstep/subway/common/exception/DuplicateAttributeException.java
+++ b/src/main/java/nextstep/subway/common/exception/DuplicateAttributeException.java
@@ -1,0 +1,8 @@
+package nextstep.subway.common.exception;
+
+public class DuplicateAttributeException extends RuntimeException{
+
+    public DuplicateAttributeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -2,5 +2,8 @@ package nextstep.subway.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LineRepository extends JpaRepository<Line, Long> {
+    Optional<Line> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/domain/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/StationRepository.java
@@ -3,8 +3,11 @@ package nextstep.subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
     @Override
     List<Station> findAll();
+
+    Optional<Station> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/ui/ExceptionController.java
+++ b/src/main/java/nextstep/subway/ui/ExceptionController.java
@@ -1,0 +1,21 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.common.exception.DuplicateAttributeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ControllerAdvice
+public class ExceptionController {
+
+    private Logger log = LoggerFactory.getLogger(ExceptionController.class);
+
+    @ResponseStatus(HttpStatus.CONFLICT)
+    @ExceptionHandler(DuplicateAttributeException.class)
+    public void handleDuplicateAttributeException(final DuplicateAttributeException ex) {
+        log.info(ex.getMessage());
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -193,4 +193,38 @@ class LineAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    /**
+     * Given 지하철 노선 생성을 요청 하고
+     * When 같은 이름으로 지하철 노선 생성을 요청 하면
+     * Then 지하철 노선 생성이 실패한다.
+     */
+    @DisplayName("중복 이름으로 지하철 노선 생성")
+    @Test
+    void createLineWithDuplicateName() {
+        // given
+        var params = new HashMap<String, String>();
+        params.put("color", "bg-red-600");
+        params.put("name", "신분당선");
+
+        var createResponse = RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // when
+        var response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,17 +1,19 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
+import nextstep.subway.acceptance.rest.BaseCrudStep;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
+
+    private final String LINE_PATH = "/lines";
+
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -20,18 +22,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine() {
         // given
-        var params = new HashMap<String, String>();
-        params.put("color", "bg-red-600");
-        params.put("name", "신분당선");
+        var params = giveMeLineRequest("신분당선", "bg-red-600");
 
         // when
-        var response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var response = BaseCrudStep.createResponse(LINE_PATH, params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -48,36 +42,14 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        var params1 = new HashMap<String, String>();
-        params1.put("color", "bg-red-600");
-        params1.put("name", "신분당선");
-        var createResponse1 = RestAssured.given().log().all()
-                .body(params1)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var params1 = giveMeLineRequest("신분당선", "bg-red-600");
+        var createResponse1 = BaseCrudStep.createResponse(LINE_PATH, params1);
 
-        var params2 = new HashMap<String, String>();
-        params2.put("color", "bg-green-600");
-        params2.put("name", "2호선");
-
-        var createResponse2 = RestAssured.given().log().all()
-                .body(params2)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var params2 = giveMeLineRequest("2호선", "bg-green-600");
+        var createResponse2 = BaseCrudStep.createResponse(LINE_PATH, params2);
 
         // when
-        var response = RestAssured.given().log().all()
-                .accept(ContentType.JSON)
-                .when()
-                .get("/lines")
-                .then().log().all()
-                .extract();
+        var response = BaseCrudStep.readResponse(LINE_PATH);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -94,26 +66,12 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
-        var params = new HashMap<String, String>();
-        params.put("color", "bg-red-600");
-        params.put("name", "신분당선");
-
-        var createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var params = giveMeLineRequest("신분당선", "bg-red-600");
+        var createResponse = BaseCrudStep.createResponse(LINE_PATH, params);
 
         // when
         var uri = createResponse.header("Location");
-        var response = RestAssured.given().log().all()
-                .accept(ContentType.JSON)
-                .when()
-                .get(uri)
-                .then().log().all()
-                .extract();
+        var response = BaseCrudStep.readResponse(uri);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -129,31 +87,14 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine() {
         // given
-        var params = new HashMap<String, String>();
-        params.put("color", "bg-red-600");
-        params.put("name", "신분당선");
-
-        var createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var params = giveMeLineRequest("신분당선", "bg-red-600");
+        var createResponse = BaseCrudStep.createResponse(LINE_PATH, params);
 
         // when
-        var modifyParams = new HashMap<String, String>();
-        modifyParams.put("color", "bg-blue-600");
-        modifyParams.put("name", "구분당선");
+        var modifyParams = giveMeLineRequest("구분당선", "bg-blue-600");
 
         var uri = createResponse.header("Location");
-        var response = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .body(modifyParams)
-                .when()
-                .put(uri)
-                .then().log().all()
-                .extract();
+        var response = BaseCrudStep.updateResponse(uri, modifyParams);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -170,25 +111,12 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        var params = new HashMap<String, String>();
-        params.put("color", "bg-red-600");
-        params.put("name", "신분당선");
-
-        var createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var params = giveMeLineRequest("신분당선", "bg-red-600");
+        var createResponse = BaseCrudStep.createResponse(LINE_PATH, params);
 
         // when
         var uri = createResponse.header("Location");
-        var response = RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .delete(uri)
-                .then().log().all()
-                .extract();
+        var response = BaseCrudStep.deleteResponse(uri);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -203,28 +131,23 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLineWithDuplicateName() {
         // given
-        var params = new HashMap<String, String>();
-        params.put("color", "bg-red-600");
-        params.put("name", "신분당선");
-
-        var createResponse = RestAssured.given().log().all()
-                .body(params)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var params = giveMeLineRequest("신분당선", "bg-red-600");
+        var createResponse = BaseCrudStep.createResponse(LINE_PATH, params);
 
         // when
-        var response = RestAssured.given().log().all()
-                .body(params)
-                .contentType(ContentType.JSON)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
+        var response = BaseCrudStep.createResponse(LINE_PATH, params);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    private Map<String, String> giveMeLineRequest(
+            String name,
+            String color
+    ) {
+        return Map.of(
+                "name", name,
+                "color", color
+        );
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,6 +1,7 @@
 package nextstep.subway.acceptance;
 
 import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -114,5 +115,38 @@ class StationAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    /**
+     * Given 지하철역 생성을 요청 하고
+     * When 같은 이름으로 지하철역 생성을 요청 하면
+     * Then 지하철역 생성이 실패한다.
+     */
+    @DisplayName("중복이름으로 지하철역 생성")
+    @Test
+    void createStationWithDuplicateName() {
+        // given
+        var params = new HashMap<String, String>();
+        params.put("name", "강남역");
+
+        var createResponse = RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+
+        // when
+        var response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/rest/BaseCrudStep.java
+++ b/src/test/java/nextstep/subway/acceptance/rest/BaseCrudStep.java
@@ -1,0 +1,54 @@
+package nextstep.subway.acceptance.rest;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+public class BaseCrudStep {
+
+    public static ExtractableResponse<Response> createResponse(
+            String uri,
+            Map<String, String> params
+    ) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> readResponse(String uri) {
+        return RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .when()
+                .get(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> updateResponse(
+            String uri,
+            Map<String, String> params
+    ) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when()
+                .put(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> deleteResponse(String uri) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .delete(uri)
+                .then().log().all()
+                .extract();
+    }
+}


### PR DESCRIPTION
안녕하세요~ 영철님😃

지난번에 피드백 주신 dto 생성 책임 관련해서 서비스 내의 비공개 메서드에서 dto의 정적 팩토리메서드로 리팩토링 해봤습니다.

중복 안되도록 처리하면서 중복 익셉션을 도입해서 해당 예외 발생시 ControllerAdvice에서 409를 리턴하도록 구현하였습니다.

인수테스트의 중복코드를 리팩터링하면서 나름대로 분리해봤는데 좋은 방향인지 궁금합니다~

리뷰 잘 부탁드립니다🙇‍♂️
