### PR TITLE
Step3: 지하철 구간 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ dependencies {
 	// log
 	implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'io.rest-assured:rest-assured:3.3.0'
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -20,8 +20,9 @@ public class LineService {
     }
 
     public LineResponse saveLine(LineRequest request) {
+        checkDuplication(request);
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        return new LineResponse(
+        return LineResponse.of(
                 line.getId(),
                 line.getName(),
                 line.getColor(),
@@ -30,11 +31,17 @@ public class LineService {
         );
     }
 
+    private void checkDuplication(LineRequest request) {
+        if (lineRepository.findByName(request.getName()).isPresent()) {
+            throw new IllegalArgumentException("[duplication]:name");
+        }
+    }
+
     public List<LineResponse> findAllLines() {
         List<Line> lines = lineRepository.findAll();
         return lines.stream()
                 .map( line ->
-                        new LineResponse(
+                        LineResponse.of(
                                 line.getId(),
                                 line.getName(),
                                 line.getColor(),
@@ -46,7 +53,7 @@ public class LineService {
 
     public LineResponse getLine(Long id) {
         Line line = lineRepository.getById(id);
-        return new LineResponse(
+        return LineResponse.of(
                 line.getId(),
                 line.getName(),
                 line.getColor(),
@@ -55,17 +62,10 @@ public class LineService {
         );
     }
 
-    public LineResponse updateLine(Long id, LineRequest lineRequest) {
+    public void updateLine(Long id, LineRequest lineRequest) {
         Line line = lineRepository.getById(id);
-        line.modify(lineRequest.getName(), lineRequest.getColor());
-        lineRepository.save(line);
-        return new LineResponse(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                line.getCreatedDate(),
-                line.getModifiedDate()
-        );
+        line.setName(lineRequest.getName());
+        line.setColor(lineRequest.getColor());
     }
 
     public void deleteLine(Long id) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -125,10 +125,9 @@ public class LineService {
                 .orElseThrow(EntityNotFoundException::new);
         Line line = lineRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
-        List<Section> sections = line.getSections();
         if (line.getSections().size() <= 1) { throw new InvalidParameterException(); }
 
-        Section lastSection = sections.get(sections.size() - 1);
+        Section lastSection = line.getLastSection();
         if (!lastSection.getDownStation().equals(station)) { throw new InvalidParameterException(); }
         line.getSections().remove(lastSection);
     }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -28,7 +28,7 @@ public class LineService {
     }
 
     public LineResponse saveLine(LineRequest request) {
-        checkDuplication(request);
+        checkDuplicatedName(request);
         existsStation(request.getUpStationId());
         existsStation(request.getDownStationId());
         checkDistanceLessThanZero(request.getDistance());
@@ -47,7 +47,7 @@ public class LineService {
         return createLineResponse(line);
     }
 
-    private void checkDuplication(LineRequest request) {
+    private void checkDuplicatedName(LineRequest request) {
         if (lineRepository.existsByName(request.getName())) {
             throw new IllegalArgumentException("[duplication]:name");
         }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -27,6 +27,7 @@ public class LineService {
         checkDuplication(request);
         existsStation(request.getUpStationId());
         existsStation(request.getDownStationId());
+        checkDistanceLessThanZero(request.getDistance());
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
         return createLineResponse(line);
     }
@@ -40,6 +41,12 @@ public class LineService {
     private void existsStation(Long upStationId) {
         if (upStationId == null || !stationRepository.existsById(upStationId)) {
             throw new NotExistedStationException("[notExist]:stationId");
+        }
+    }
+
+    private void checkDistanceLessThanZero(int distance) {
+        if (distance <= 0) {
+            throw new NotExistedStationException("[notValid]:distance");
         }
     }
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -125,10 +125,10 @@ public class LineService {
                 .orElseThrow(EntityNotFoundException::new);
         Line line = lineRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
-        line.getSections()
-                .stream()
-                .filter(t -> t.getDownStation().getId().equals(stationId))
-                .findFirst()
-                .orElseThrow(EntityNotFoundException::new);
+        List<Section> sections = line.getSections();
+
+        Section lastSection = sections.get(sections.size() - 1);
+        if (!lastSection.getDownStation().equals(station)) { throw new InvalidParameterException(); }
+        line.getSections().remove(lastSection);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
+import java.security.InvalidParameterException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -98,12 +99,15 @@ public class LineService {
     }
 
     public void saveSection(Long id, SectionRequest request) {
-        Line line = lineRepository.findById(id)
-                .orElseThrow(EntityNotFoundException::new);
+        existsStation(request.getUpStationId());
+        existsStation(request.getDownStationId());
         Station upStation = stationRepository.findById(request.getUpStationId())
                 .orElseThrow(EntityNotFoundException::new);
         Station downStation = stationRepository.findById(request.getDownStationId())
                 .orElseThrow(EntityNotFoundException::new);
+        Line line = lineRepository.findById(id)
+                .orElseThrow(EntityNotFoundException::new);
+        if (!line.equalsLastDownStation(upStation)) { throw new InvalidParameterException(); }
         Section section = new Section(
                 line,
                 upStation,

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -108,6 +108,7 @@ public class LineService {
         Line line = lineRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
         if (!line.equalsLastDownStation(upStation)) { throw new InvalidParameterException(); }
+        if (line.checkDuplicatedDownStation(downStation))  { throw new InvalidParameterException(); }
         Section section = new Section(
                 line,
                 upStation,

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -126,6 +126,7 @@ public class LineService {
         Line line = lineRepository.findById(id)
                 .orElseThrow(EntityNotFoundException::new);
         List<Section> sections = line.getSections();
+        if (line.getSections().size() <= 1) { throw new InvalidParameterException(); }
 
         Section lastSection = sections.get(sections.size() - 1);
         if (!lastSection.getDownStation().equals(station)) { throw new InvalidParameterException(); }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -12,6 +12,7 @@ import nextstep.subway.exception.NotExistedStationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -33,7 +34,18 @@ public class LineService {
         existsStation(request.getDownStationId());
         equalsUpDownStation(request.getUpStationId(), request.getDownStationId());
         checkDistanceLessThanZero(request.getDistance());
+        Station upStation = stationRepository.findById(request.getUpStationId())
+                .orElseThrow(EntityNotFoundException::new);
+        Station downStation = stationRepository.findById(request.getDownStationId())
+                .orElseThrow(EntityNotFoundException::new);
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
+        Section section = new Section(
+                line,
+                upStation,
+                downStation,
+                request.getDistance()
+        );
+        line.addSection(section);
         return createLineResponse(line);
     }
 
@@ -95,11 +107,11 @@ public class LineService {
 
     public void saveSection(Long id, SectionRequest request) {
         Line line = lineRepository.findById(id)
-                .orElseThrow(NotExistedStationException::new);
+                .orElseThrow(EntityNotFoundException::new);
         Station upStation = stationRepository.findById(request.getUpStationId())
-                .orElseThrow(NotExistedStationException::new);
+                .orElseThrow(EntityNotFoundException::new);
         Station downStation = stationRepository.findById(request.getDownStationId())
-                .orElseThrow(NotExistedStationException::new);
+                .orElseThrow(EntityNotFoundException::new);
         Section section = new Section(
                 line,
                 upStation,

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -38,12 +38,12 @@ public class LineService {
         Station downStation = stationRepository.findById(request.getDownStationId())
                 .orElseThrow(EntityNotFoundException::new);
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        Section section = new Section(
-                line,
-                upStation,
-                downStation,
-                request.getDistance()
-        );
+        Section section = Section.builder()
+                .line(line)
+                .upStation(upStation)
+                .downStation(downStation)
+                .distance(request.getDistance())
+                .build();
         line.addSection(section);
         return createLineResponse(line);
     }
@@ -79,14 +79,14 @@ public class LineService {
     }
 
     private LineResponse createLineResponse(Line line) {
-        return new LineResponse(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                line.getCreatedDate(),
-                line.getModifiedDate(),
-                line.getStations()
-        );
+        return LineResponse.builder()
+                .id(line.getId())
+                .name(line.getName())
+                .color(line.getColor())
+                .createdDate(line.getCreatedDate())
+                .modifiedDate(line.getModifiedDate())
+                .stations(line.getStations())
+                .build();
     }
 
     public void updateLine(Long id, LineRequest lineRequest) {
@@ -110,12 +110,12 @@ public class LineService {
                 .orElseThrow(EntityNotFoundException::new);
         if (!line.equalsLastDownStation(upStation)) { throw new InvalidParameterException(); }
         if (line.checkDuplicatedDownStation(downStation))  { throw new InvalidParameterException(); }
-        Section section = new Section(
-                line,
-                upStation,
-                downStation,
-                request.getDistance()
-        );
+        Section section = Section.builder()
+                .line(line)
+                .upStation(upStation)
+                .downStation(downStation)
+                .distance(request.getDistance())
+                .build();
         line.addSection(section);
     }
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -39,7 +39,7 @@ public class LineService {
 
     private void existsStation(Long upStationId) {
         if (upStationId == null || !stationRepository.existsById(upStationId)) {
-            throw new NotExistedStationException("[duplication]:name");
+            throw new NotExistedStationException("[notExist]:stationId");
         }
     }
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -26,6 +26,7 @@ public class LineService {
     public LineResponse saveLine(LineRequest request) {
         checkDuplication(request);
         existsStation(request.getUpStationId());
+        existsStation(request.getDownStationId());
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
         return createLineResponse(line);
     }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -22,13 +22,7 @@ public class LineService {
     public LineResponse saveLine(LineRequest request) {
         checkDuplication(request);
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
-        return LineResponse.of(
-                line.getId(),
-                line.getName(),
-                line.getColor(),
-                line.getCreatedDate(),
-                line.getModifiedDate()
-        );
+        return createLineResponse(line);
     }
 
     private void checkDuplication(LineRequest request) {
@@ -40,20 +34,17 @@ public class LineService {
     public List<LineResponse> findAllLines() {
         List<Line> lines = lineRepository.findAll();
         return lines.stream()
-                .map( line ->
-                        LineResponse.of(
-                                line.getId(),
-                                line.getName(),
-                                line.getColor(),
-                                line.getCreatedDate(),
-                                line.getModifiedDate()
-                        )
-                ).collect(Collectors.toList());
+                .map(this::createLineResponse)
+                .collect(Collectors.toList());
     }
 
     public LineResponse getLine(Long id) {
         Line line = lineRepository.getById(id);
-        return LineResponse.of(
+        return createLineResponse(line);
+    }
+
+    private LineResponse createLineResponse(Line line) {
+        return new LineResponse(
                 line.getId(),
                 line.getName(),
                 line.getColor(),

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -64,8 +64,7 @@ public class LineService {
 
     public void updateLine(Long id, LineRequest lineRequest) {
         Line line = lineRepository.getById(id);
-        line.setName(lineRequest.getName());
-        line.setColor(lineRequest.getColor());
+        line.update(lineRequest.getName(), lineRequest.getColor());
     }
 
     public void deleteLine(Long id) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -27,6 +27,7 @@ public class LineService {
         checkDuplication(request);
         existsStation(request.getUpStationId());
         existsStation(request.getDownStationId());
+        equalsUpDownStation(request.getUpStationId(), request.getDownStationId());
         checkDistanceLessThanZero(request.getDistance());
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
         return createLineResponse(line);
@@ -47,6 +48,12 @@ public class LineService {
     private void checkDistanceLessThanZero(int distance) {
         if (distance <= 0) {
             throw new NotExistedStationException("[notValid]:distance");
+        }
+    }
+
+    private void equalsUpDownStation(Long upStationId, Long downStationId) {
+        if (upStationId.equals(downStationId)) {
+            throw new NotExistedStationException("[notValid]:upStationId, downStationId");
         }
     }
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -32,7 +32,7 @@ public class LineService {
     }
 
     private void checkDuplication(LineRequest request) {
-        if (lineRepository.findByName(request.getName()).isPresent()) {
+        if (lineRepository.existsByName(request.getName())) {
             throw new IllegalArgumentException("[duplication]:name");
         }
     }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -118,4 +118,17 @@ public class LineService {
         );
         line.addSection(section);
     }
+
+    public void deleteSection(Long id, Long stationId) {
+        existsStation(stationId);
+        Station station = stationRepository.findById(stationId)
+                .orElseThrow(EntityNotFoundException::new);
+        Line line = lineRepository.findById(id)
+                .orElseThrow(EntityNotFoundException::new);
+        line.getSections()
+                .stream()
+                .filter(t -> t.getDownStation().getId().equals(stationId))
+                .findFirst()
+                .orElseThrow(EntityNotFoundException::new);
+    }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -2,14 +2,18 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
 import nextstep.subway.exception.NotExistedStationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -87,5 +91,21 @@ public class LineService {
     public void deleteLine(Long id) {
         Line line = lineRepository.getById(id);
         lineRepository.deleteById(line.getId());
+    }
+
+    public void saveSection(Long id, SectionRequest request) {
+        Line line = lineRepository.findById(id)
+                .orElseThrow(NotExistedStationException::new);
+        Station upStation = stationRepository.findById(request.getUpStationId())
+                .orElseThrow(NotExistedStationException::new);
+        Station downStation = stationRepository.findById(request.getDownStationId())
+                .orElseThrow(NotExistedStationException::new);
+        Section section = new Section(
+                line,
+                upStation,
+                downStation,
+                request.getDistance()
+        );
+        line.addSection(section);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -84,7 +84,8 @@ public class LineService {
                 line.getName(),
                 line.getColor(),
                 line.getCreatedDate(),
-                line.getModifiedDate()
+                line.getModifiedDate(),
+                line.getStations()
         );
     }
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -7,6 +7,9 @@ import nextstep.subway.domain.LineRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @Transactional
 public class LineService {
@@ -25,5 +28,48 @@ public class LineService {
                 line.getCreatedDate(),
                 line.getModifiedDate()
         );
+    }
+
+    public List<LineResponse> findAllLines() {
+        List<Line> lines = lineRepository.findAll();
+        return lines.stream()
+                .map( line ->
+                        new LineResponse(
+                                line.getId(),
+                                line.getName(),
+                                line.getColor(),
+                                line.getCreatedDate(),
+                                line.getModifiedDate()
+                        )
+                ).collect(Collectors.toList());
+    }
+
+    public LineResponse getLine(Long id) {
+        Line line = lineRepository.getById(id);
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                line.getCreatedDate(),
+                line.getModifiedDate()
+        );
+    }
+
+    public LineResponse updateLine(Long id, LineRequest lineRequest) {
+        Line line = lineRepository.getById(id);
+        line.modify(lineRequest.getName(), lineRequest.getColor());
+        lineRepository.save(line);
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                line.getCreatedDate(),
+                line.getModifiedDate()
+        );
+    }
+
+    public void deleteLine(Long id) {
+        Line line = lineRepository.getById(id);
+        lineRepository.deleteById(line.getId());
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -55,7 +55,7 @@ public class LineService {
     }
 
     private void existsStation(Long upStationId) {
-        if (upStationId == null || !stationRepository.existsById(upStationId)) {
+        if (upStationId == null) {
             throw new NotExistedStationException("[notExist]:stationId");
         }
     }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -62,7 +62,7 @@ public class LineService {
     }
 
     private void checkDistanceLessThanZero(int distance) {
-        if (distance <= 0) {
+        if (distance < 0) {
             throw new NotExistedStationException("[notValid]:distance");
         }
     }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -14,7 +14,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -32,7 +31,6 @@ public class LineService {
         checkDuplication(request);
         existsStation(request.getUpStationId());
         existsStation(request.getDownStationId());
-        equalsUpDownStation(request.getUpStationId(), request.getDownStationId());
         checkDistanceLessThanZero(request.getDistance());
         Station upStation = stationRepository.findById(request.getUpStationId())
                 .orElseThrow(EntityNotFoundException::new);
@@ -64,12 +62,6 @@ public class LineService {
     private void checkDistanceLessThanZero(int distance) {
         if (distance < 0) {
             throw new NotExistedStationException("[notValid]:distance");
-        }
-    }
-
-    private void equalsUpDownStation(Long upStationId, Long downStationId) {
-        if (upStationId.equals(downStationId)) {
-            throw new NotExistedStationException("[notValid]:upStationId, downStationId");
         }
     }
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -4,6 +4,8 @@ import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.StationRepository;
+import nextstep.subway.exception.NotExistedStationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,14 +15,17 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class LineService {
-    private LineRepository lineRepository;
+    private final LineRepository lineRepository;
+    private final StationRepository stationRepository;
 
-    public LineService(LineRepository lineRepository) {
+    public LineService(LineRepository lineRepository, StationRepository stationRepository) {
         this.lineRepository = lineRepository;
+        this.stationRepository = stationRepository;
     }
 
     public LineResponse saveLine(LineRequest request) {
         checkDuplication(request);
+        existsStation(request.getUpStationId());
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
         return createLineResponse(line);
     }
@@ -28,6 +33,12 @@ public class LineService {
     private void checkDuplication(LineRequest request) {
         if (lineRepository.existsByName(request.getName())) {
             throw new IllegalArgumentException("[duplication]:name");
+        }
+    }
+
+    private void existsStation(Long upStationId) {
+        if (upStationId == null || !stationRepository.existsById(upStationId)) {
+            throw new NotExistedStationException("[duplication]:name");
         }
     }
 

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -26,7 +26,7 @@ public class StationService {
     }
 
     private void checkDuplication(StationRequest stationRequest) {
-        if (stationRepository.findByName(stationRequest.getName()).isPresent()) {
+        if (stationRepository.existsByName(stationRequest.getName())) {
             throw new IllegalArgumentException("[duplication]:name");
         }
     }

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -20,8 +20,15 @@ public class StationService {
     }
 
     public StationResponse saveStation(StationRequest stationRequest) {
+        checkDuplication(stationRequest);
         Station station = stationRepository.save(new Station(stationRequest.getName()));
         return createStationResponse(station);
+    }
+
+    private void checkDuplication(StationRequest stationRequest) {
+        if (stationRepository.findByName(stationRequest.getName()).isPresent()) {
+            throw new IllegalArgumentException("[duplication]:name");
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -3,6 +3,9 @@ package nextstep.subway.applicaion.dto;
 public class LineRequest {
     private String name;
     private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
 
     public String getName() {
         return name;
@@ -10,5 +13,17 @@ public class LineRequest {
 
     public String getColor() {
         return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -17,6 +17,10 @@ public class LineResponse {
         this.modifiedDate = modifiedDate;
     }
 
+    public static LineResponse of(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+        return new LineResponse(id, name, color, createdDate, modifiedDate);
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,22 +1,34 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Station;
+
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class LineResponse {
     private Long id;
     private String name;
     private String color;
+    private List<Station> stations;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
-    public LineResponse(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+    public LineResponse(
+            Long id,
+            String name,
+            String color,
+            LocalDateTime createdDate,
+            LocalDateTime modifiedDate,
+            List<Station> stations
+    ) {
         this.id = id;
         this.name = name;
         this.color = color;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
+        this.stations = stations;
     }
-    
+
     public Long getId() {
         return id;
     }
@@ -35,5 +47,9 @@ public class LineResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public List<Station> getStations() {
+        return stations;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,5 +1,6 @@
 package nextstep.subway.applicaion.dto;
 
+import lombok.Builder;
 import nextstep.subway.domain.Station;
 
 import java.time.LocalDateTime;
@@ -13,6 +14,7 @@ public class LineResponse {
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
+    @Builder
     public LineResponse(
             Long id,
             String name,

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -16,11 +16,7 @@ public class LineResponse {
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
     }
-
-    public static LineResponse of(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate) {
-        return new LineResponse(id, name, color, createdDate, modifiedDate);
-    }
-
+    
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -1,0 +1,19 @@
+package nextstep.subway.applicaion.dto;
+
+public class SectionRequest {
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -3,11 +3,13 @@ package nextstep.subway.domain;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Entity
@@ -21,7 +23,7 @@ public class Line extends BaseEntity {
     private String color;
 
     @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
-    private List<Section> sections = new ArrayList<>();
+    private final List<Section> sections = new ArrayList<>();
 
     public Line() {
     }
@@ -50,7 +52,6 @@ public class Line extends BaseEntity {
         section.setLine(this);
     }
 
-
     public void update(String name, String color) {
         if (name != null && !name.isEmpty()) {
             this.name = name;
@@ -59,5 +60,16 @@ public class Line extends BaseEntity {
         if (color != null && !color.isEmpty()) {
             this.color = color;
         }
+    }
+
+    public Section getLastDownStation() {
+        return this.getSections()
+                .stream()
+                .max(Comparator.comparing(Section::getId))
+                .orElseThrow(EntityNotFoundException::new);
+    }
+
+    public boolean equalsLastDownStation(Station upStation) {
+        return getLastDownStation().getDownStation().equals(upStation);
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -11,6 +11,7 @@ import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Entity
@@ -75,14 +76,23 @@ public class Line extends BaseEntity {
     }
 
     public boolean checkDuplicatedDownStation(Station downStation) {
-        boolean duplidatedDownStation = sections.stream()
+        boolean duplicatedDownStationYn = sections.stream()
                 .map(Section::getDownStation)
                 .collect(Collectors.toSet())
                 .contains(downStation);
-        boolean duplidatedUpStation = sections.stream()
+        boolean duplicatedUpStationYn = sections.stream()
                 .map(Section::getUpStation)
                 .collect(Collectors.toSet())
                 .contains(downStation);
-        return duplidatedDownStation || duplidatedUpStation;
+        return duplicatedDownStationYn || duplicatedUpStationYn;
+    }
+
+    public List<Station> getStations() {
+        List<Station> stations = sections.stream()
+                .sorted(Comparator.comparing(Section::getId))
+                .map(Section::getUpStation)
+                .collect(Collectors.toList());
+        stations.add(getLastSection().getDownStation());
+        return stations;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -32,4 +32,21 @@ public class Line extends BaseEntity {
     public String getColor() {
         return color;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    public void modify(String name, String color) {
+        if (name != null && !name.isEmpty()) {
+            this.setName(name);
+        }
+        if (color != null && !color.isEmpty()) {
+            this.setColor(color);
+        }
+    }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -11,6 +11,7 @@ import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 public class Line extends BaseEntity {
@@ -62,14 +63,26 @@ public class Line extends BaseEntity {
         }
     }
 
-    public Section getLastDownStation() {
-        return this.getSections()
+    public Section getLastSection() {
+        return sections
                 .stream()
                 .max(Comparator.comparing(Section::getId))
                 .orElseThrow(EntityNotFoundException::new);
     }
 
     public boolean equalsLastDownStation(Station upStation) {
-        return getLastDownStation().getDownStation().equals(upStation);
+        return getLastSection().getDownStation().equals(upStation);
+    }
+
+    public boolean checkDuplicatedDownStation(Station downStation) {
+        boolean duplidatedDownStation = sections.stream()
+                .map(Section::getDownStation)
+                .collect(Collectors.toSet())
+                .contains(downStation);
+        boolean duplidatedUpStation = sections.stream()
+                .map(Section::getUpStation)
+                .collect(Collectors.toSet())
+                .contains(downStation);
+        return duplidatedDownStation || duplidatedUpStation;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -33,13 +33,11 @@ public class Line extends BaseEntity {
         return color;
     }
 
-    public void setName(String name) {
+    public void update(String name, String color) {
         if (name != null && !name.isEmpty()) {
             this.name = name;
         }
-    }
 
-    public void setColor(String color) {
         if (color != null && !color.isEmpty()) {
             this.color = color;
         }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -64,10 +64,7 @@ public class Line extends BaseEntity {
     }
 
     public Section getLastSection() {
-        return sections
-                .stream()
-                .max(Comparator.comparing(Section::getId))
-                .orElseThrow(EntityNotFoundException::new);
+        return sections.get(sections.size() - 1);
     }
 
     public boolean equalsLastDownStation(Station upStation) {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -34,19 +34,14 @@ public class Line extends BaseEntity {
     }
 
     public void setName(String name) {
-        this.name = name;
+        if (name != null && !name.isEmpty()) {
+            this.name = name;
+        }
     }
 
     public void setColor(String color) {
-        this.color = color;
-    }
-
-    public void modify(String name, String color) {
-        if (name != null && !name.isEmpty()) {
-            this.setName(name);
-        }
         if (color != null && !color.isEmpty()) {
-            this.setColor(color);
+            this.color = color;
         }
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,17 +1,27 @@
 package nextstep.subway.domain;
 
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Line extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(unique = true)
     private String name;
     private String color;
+
+    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    private List<Section> sections = new ArrayList<>();
 
     public Line() {
     }
@@ -32,6 +42,14 @@ public class Line extends BaseEntity {
     public String getColor() {
         return color;
     }
+
+    public List<Section> getSections() { return sections; }
+
+    public void addSection(Section section) {
+        sections.add(section);
+        section.setLine(this);
+    }
+
 
     public void update(String name, String color) {
         if (name != null && !name.isEmpty()) {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -11,7 +11,6 @@ import javax.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Entity

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -2,5 +2,8 @@ package nextstep.subway.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface LineRepository extends JpaRepository<Line, Long> {
+    Optional<Line> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -2,8 +2,6 @@ package nextstep.subway.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface LineRepository extends JpaRepository<Line, Long> {
-    Optional<Line> findByName(String name);
+    boolean existsByName(String name);
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,5 +1,7 @@
 package nextstep.subway.domain;
 
+import lombok.Builder;
+
 import javax.persistence.CascadeType;
 
 import javax.persistence.Entity;
@@ -32,6 +34,7 @@ public class Section extends BaseEntity {
     public Section() {
     }
 
+    @Builder
     public Section(Line line, Station upStation, Station downStation, int distance) {
         this.line = line;
         this.upStation = upStation;

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,0 +1,61 @@
+package nextstep.subway.domain;
+
+import javax.persistence.CascadeType;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity
+public class Section extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "line_id")
+    private Line line;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "up_station_id")
+    private Station upStation;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "down_station_id")
+    private Station downStation;
+
+    private int distance;
+
+    public Section() {
+    }
+
+    public Section(Line line, Station upStation, Station downStation, int distance) {
+        this.line = line;
+        this.upStation = upStation;
+        this.downStation = downStation;
+        this.distance = distance;
+    }
+
+    public void setLine(Line line) {
+        this.line = line;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Station getUpStation() {
+        return upStation;
+    }
+
+    public Station getDownStation() {
+        return downStation;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/StationRepository.java
@@ -3,8 +3,11 @@ package nextstep.subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
     @Override
     List<Station> findAll();
+
+    Optional<Station> findByName(String name);
 }

--- a/src/main/java/nextstep/subway/domain/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/StationRepository.java
@@ -3,11 +3,10 @@ package nextstep.subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
     @Override
     List<Station> findAll();
 
-    Optional<Station> findByName(String name);
+    boolean existsByName(String name);
 }

--- a/src/main/java/nextstep/subway/exception/NotExistedStationException.java
+++ b/src/main/java/nextstep/subway/exception/NotExistedStationException.java
@@ -1,7 +1,12 @@
 package nextstep.subway.exception;
 
 public class NotExistedStationException extends IllegalArgumentException {
+    public NotExistedStationException() {
+        super();
+    }
+
     public NotExistedStationException(String message) {
         super(message);
     }
+
 }

--- a/src/main/java/nextstep/subway/exception/NotExistedStationException.java
+++ b/src/main/java/nextstep/subway/exception/NotExistedStationException.java
@@ -1,0 +1,7 @@
+package nextstep.subway.exception;
+
+public class NotExistedStationException extends IllegalArgumentException {
+    public NotExistedStationException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -45,8 +45,8 @@ public class LineController {
 
     @PutMapping("/{id}")
     public ResponseEntity<LineResponse> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
-        LineResponse line = lineService.updateLine(id, lineRequest);
-        return ResponseEntity.ok().body(line);
+        lineService.updateLine(id, lineRequest);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
@@ -65,7 +66,7 @@ public class LineController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/{id}/section")
+    @PostMapping("/{id}/sections")
     public ResponseEntity<Void> createSection(@PathVariable Long id, @RequestBody SectionRequest sectionRequest) {
         try {
             lineService.saveSection(id, sectionRequest);
@@ -73,5 +74,11 @@ public class LineController {
         } catch (InvalidParameterException e) {
             return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY.value()).build();
         }
+    }
+
+    @DeleteMapping("/{id}/sections")
+    public ResponseEntity<Void> deleteSection(@PathVariable Long id, @RequestParam("stationId") Long stationId) {
+        lineService.deleteSection(id, stationId);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -3,6 +3,7 @@ package nextstep.subway.ui;
 import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -27,8 +28,12 @@ public class LineController {
 
     @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
-        LineResponse line = lineService.saveLine(lineRequest);
-        return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+        try {
+            LineResponse line = lineService.saveLine(lineRequest);
+            return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT.value()).build();
+        }
     }
 
     @GetMapping

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.security.InvalidParameterException;
 import java.util.List;
 
 @RestController
@@ -66,7 +67,11 @@ public class LineController {
 
     @PostMapping("/{id}/section")
     public ResponseEntity<Void> createSection(@PathVariable Long id, @RequestBody SectionRequest sectionRequest) {
-        lineService.saveSection(id, sectionRequest);
-        return ResponseEntity.created(URI.create("/lines/" + id + "/section")).build();
+        try {
+            lineService.saveSection(id, sectionRequest);
+            return ResponseEntity.created(URI.create("/lines/" + id + "/section")).build();
+        } catch (InvalidParameterException e) {
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY.value()).build();
+        }
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -4,12 +4,17 @@ import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/lines")
@@ -24,5 +29,29 @@ public class LineController {
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         LineResponse line = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<LineResponse>> findAllLines() {
+        List<LineResponse> lines = lineService.findAllLines();
+        return ResponseEntity.ok().body(lines);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<LineResponse> getLine(@PathVariable Long id) {
+        LineResponse line = lineService.getLine(id);
+        return ResponseEntity.ok().body(line);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<LineResponse> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+        LineResponse line = lineService.updateLine(id, lineRequest);
+        return ResponseEntity.ok().body(line);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
+        lineService.deleteLine(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,6 +1,7 @@
 package nextstep.subway.ui;
 
 import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.exception.NotExistedStationException;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
@@ -61,5 +62,11 @@ public class LineController {
     public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
         lineService.deleteLine(id);
         return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/section")
+    public ResponseEntity<Void> createSection(@PathVariable Long id, @RequestBody SectionRequest sectionRequest) {
+        lineService.saveSection(id, sectionRequest);
+        return ResponseEntity.created(URI.create("/lines/" + id + "/section")).build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,6 +1,7 @@
 package nextstep.subway.ui;
 
 import nextstep.subway.applicaion.LineService;
+import nextstep.subway.exception.NotExistedStationException;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import org.springframework.http.HttpStatus;
@@ -31,6 +32,8 @@ public class LineController {
         try {
             LineResponse line = lineService.saveLine(lineRequest);
             return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+        } catch (NotExistedStationException e) {
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY.value()).build();
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.CONFLICT.value()).build();
         }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -78,7 +78,11 @@ public class LineController {
 
     @DeleteMapping("/{id}/sections")
     public ResponseEntity<Void> deleteSection(@PathVariable Long id, @RequestParam("stationId") Long stationId) {
-        lineService.deleteSection(id, stationId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        try {
+            lineService.deleteSection(id, stationId);
+            return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        } catch (InvalidParameterException e) {
+            return ResponseEntity.status(HttpStatus.UNPROCESSABLE_ENTITY.value()).build();
+        }
     }
 }

--- a/src/main/java/nextstep/subway/ui/StationController.java
+++ b/src/main/java/nextstep/subway/ui/StationController.java
@@ -3,6 +3,7 @@ package nextstep.subway.ui;
 import nextstep.subway.applicaion.StationService;
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,8 +21,12 @@ public class StationController {
 
     @PostMapping("/stations")
     public ResponseEntity<StationResponse> createStation(@RequestBody StationRequest stationRequest) {
-        StationResponse station = stationService.saveStation(stationRequest);
-        return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(station);
+        try{
+            StationResponse station = stationService.saveStation(stationRequest);
+            return ResponseEntity.created(URI.create("/stations/" + station.getId())).body(station);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT.value()).build();
+        }
     }
 
     @GetMapping(value = "/stations", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
+    
     @LocalServerPort
     int port;
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -234,6 +234,27 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
+    /**
+     * When 지하철 노선 구간 생성을 요청 하면,
+     * Then 지하철 노선 구간 생성이 성공한다.
+     * @see nextstep.subway.ui.LineController#createSection
+     */
+    @DisplayName("지하철 노선 구간 등록 테스트")
+    @Test
+    void 지하철_노선_구간_등록_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+        ApiUtil.지하철역_생성_API(삼성역);
+        ApiUtil.지하철_노선_생성_API(GTXA노선);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
     static Map<String, String> GTXA노선;
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
@@ -244,8 +265,11 @@ class LineAcceptanceTest extends AcceptanceTest {
 
     static Map<String, String> 연신내역;
     static Map<String, String> 서울역;
+    static Map<String, String> 삼성역;
     static Map<String, String> 강남역;
     static Map<String, String> 양재역;
+
+    static Map<String, String> GTXA노선_구간;
 
     @BeforeAll
     public static void 초기화() {
@@ -253,6 +277,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         연신내역.put("name", "연신내");
         서울역 = new HashMap<>();
         서울역.put("name", "서울역");
+        삼성역 = new HashMap<>();
+        삼성역.put("name", "삼성역");
         강남역 = new HashMap<>();
         강남역.put("name", "강남역");
         양재역 = new HashMap<>();
@@ -299,5 +325,10 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         노선색상 = new HashMap<>();
         노선색상.put("color", "bg-red-800");
+
+        GTXA노선_구간 = new HashMap<>();
+        GTXA노선_구간.put("upStationId", "2");
+        GTXA노선_구간.put("downStationId", "3");
+        GTXA노선_구간.put("distance", "10");
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -254,7 +254,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간_연신내역_삼성역);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
     static Map<String, String> GTXA노선_연신내_서울역;

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -168,6 +168,34 @@ class LineAcceptanceTest extends AcceptanceTest {
     }
 
     /**
+     * Given 지하철 노선 생성 및 구간등록 요청 하고,
+     * When 생성한 지하철 노선 조회를 요청 하면
+     * Then 생성한 지하철 노선 역을 응답받는다
+     * @see nextstep.subway.ui.LineController#getLine
+     */
+    @DisplayName("지하철 노선역 조회 테스트")
+    @Test
+    void 지하철_노선역_조회_테스트() {
+        // given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+        ApiUtil.지하철역_생성_API(삼성역);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
+        ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간_서울역_삼성역);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_단건_조회_API(1L);
+
+        // then
+        List<HashMap<String, String>> stations = response.body().jsonPath().getList("stations");
+        assertThat(stations.size()).isEqualTo(3);
+        System.out.println(stations.get(0).get("name"));
+        assertThat(stations.get(0).get("name").equals("연신내")).isTrue();
+        assertThat(stations.get(1).get("name").equals("서울역")).isTrue();
+        assertThat(stations.get(2).get("name").equals("삼성역")).isTrue();
+    }
+
+    /**
      * Given 지하철 노선 생성을 요청 하고
      * When 지하철 노선의 정보 수정을 요청 하면
      * Then 지하철 노선의 정보 수정은 성공한다.
@@ -268,7 +296,6 @@ class LineAcceptanceTest extends AcceptanceTest {
         //given
         ApiUtil.지하철역_생성_API(연신내역);
         ApiUtil.지하철역_생성_API(서울역);
-        ApiUtil.지하철역_생성_API(삼성역);
         ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // when

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -106,7 +106,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         ApiUtil.지하철역_생성_API(서울역);
 
         // when
-        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_거리_정보없음);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_거리_음수);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
@@ -239,7 +239,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     static Map<String, String> GTXA노선;
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
-    static Map<String, String> GTXA노선_거리_정보없음;
+    static Map<String, String> GTXA노선_거리_음수;
     static Map<String, String> 신분당선;
     static Map<String, String> 노선색상;
 
@@ -283,11 +283,12 @@ class LineAcceptanceTest extends AcceptanceTest {
         GTXA노선_하행_정보없음.put("upStationId", "1");
         GTXA노선_하행_정보없음.put("distance", "10");
 
-        GTXA노선_거리_정보없음 = new HashMap<>();
-        GTXA노선_거리_정보없음.put("name", "GTX-A");
-        GTXA노선_거리_정보없음.put("color", "bg-red-900");
-        GTXA노선_거리_정보없음.put("upStationId", "1");
-        GTXA노선_거리_정보없음.put("downStationId", "2");
+        GTXA노선_거리_음수 = new HashMap<>();
+        GTXA노선_거리_음수.put("name", "GTX-A");
+        GTXA노선_거리_음수.put("color", "bg-red-900");
+        GTXA노선_거리_음수.put("upStationId", "1");
+        GTXA노선_거리_음수.put("downStationId", "2");
+        GTXA노선_거리_음수.put("distance", "-1");
 
         신분당선 = new HashMap<>();
         신분당선.put("name", "신분당선");

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -46,7 +46,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -288,6 +288,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         GTXA노선_상행_하행_정보같음.put("color", "bg-red-900");
         GTXA노선_상행_하행_정보같음.put("upStationId", "1");
         GTXA노선_상행_하행_정보같음.put("downStationId", "1");
+        GTXA노선_상행_하행_정보같음.put("distance", "10");
 
         신분당선 = new HashMap<>();
         신분당선.put("name", "신분당선");

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -328,6 +328,29 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
+    /**
+     * Given 지하철 노선 생성 및 노선 구간 생성을 하고,
+     * When 하행 종점이 아닌 지하철 노선 구간 삭제를 요청 하면
+     * Then 생성한 지하철 노선 구간 삭제가 실패한다.
+     * @see nextstep.subway.ui.LineController#deleteSection
+     */
+    @DisplayName("지하철 노선 하행 종점이 아닌 구간 삭제 방지 테스트")
+    @Test
+    void 지하철_노선_하행_종점_아닌_구간_삭제_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+        ApiUtil.지하철역_생성_API(삼성역);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
+        ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간_서울역_삼성역);
+
+        // when
+        ExtractableResponse<Response> deleteResponse = ApiUtil.지하철_노선_구간_삭제_API(1L, GTXA노선_구간_삭제_연신내);
+
+        // then
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
     static Map<String, String> GTXA노선_연신내_서울역;
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
@@ -346,6 +369,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     static Map<String, String> GTXA노선_구간_서울역_연신내역;
 
     static Map<String, String> GTXA노선_구간_삭제_삼성역;
+    static Map<String, String> GTXA노선_구간_삭제_연신내;
 
     @BeforeAll
     public static void 초기화() {
@@ -413,5 +437,8 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         GTXA노선_구간_삭제_삼성역 = new HashMap<>();
         GTXA노선_구간_삭제_삼성역.put("stationId", "3");
+
+        GTXA노선_구간_삭제_연신내 = new HashMap<>();
+        GTXA노선_구간_삭제_연신내.put("stationId", "1");
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -305,6 +305,29 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
+    /**
+     * Given 지하철 노선 생성 및 노선 구간 생성을 하고,
+     * When 생성한 지하철 노선 구간 삭제를 요청 하면
+     * Then 생성한 지하철 노선 구간 삭제가 성공한다.
+     * @see nextstep.subway.ui.LineController#deleteSetion
+     */
+    @DisplayName("지하철 노선 구간 삭제 테스트")
+    @Test
+    void 지하철_노선_구간_삭제_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+        ApiUtil.지하철역_생성_API(삼성역);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
+        ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간_서울역_삼성역);
+
+        // when
+        ExtractableResponse<Response> deleteResponse = ApiUtil.지하철_노선_구간_삭제_API(1L, GTXA노선_구간_삭제_삼성역);
+
+        // then
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
     static Map<String, String> GTXA노선_연신내_서울역;
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
@@ -321,6 +344,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     static Map<String, String> GTXA노선_구간_서울역_삼성역;
     static Map<String, String> GTXA노선_구간_연신내역_삼성역;
     static Map<String, String> GTXA노선_구간_서울역_연신내역;
+
+    static Map<String, String> GTXA노선_구간_삭제_삼성역;
 
     @BeforeAll
     public static void 초기화() {
@@ -385,5 +410,8 @@ class LineAcceptanceTest extends AcceptanceTest {
         GTXA노선_구간_서울역_연신내역.put("upStationId", "2");
         GTXA노선_구간_서울역_연신내역.put("downStationId", "1");
         GTXA노선_구간_서울역_연신내역.put("distance", "10");
+
+        GTXA노선_구간_삭제_삼성역 = new HashMap<>();
+        GTXA노선_구간_삭제_삼성역.put("stationId", "3");
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -22,6 +22,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선 생성 테스트")
     @Test
     void 지하철_노선_생성_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+
         // when
         ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선);
 
@@ -36,10 +40,12 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Then 지하철 노선 생성이 실패한다.
      * @see nextstep.subway.ui.LineController#createLine
      */
-    @DisplayName("지하철 노선 이름 중복 생성 방지 테스트")
+    @DisplayName("[예외]지하철 노선 이름 중복 생성 방지 테스트")
     @Test
     void 지하철_노선_이름_중복_생성_방지_테스트() {
-        // given
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
         ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
@@ -47,6 +53,82 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    /**
+     * When 지하철 노선 생성을 요청 했을 때 상행 역 정보가 없으면,
+     * Then 지하철 노선 생성이 실패한다.
+     * @see nextstep.subway.ui.LineController#createLine
+     */
+    @DisplayName("[예외]지하철 노선 상행 등록정보 없음 방지 테스트")
+    @Test
+    void 지하철_노선_상행_등록정보_없음_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_상행_정보없음);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
+    /**
+     * When 지하철 노선 생성을 요청 했을 때 하행 역 정보가 없으면,
+     * Then 지하철 노선 생성이 실패한다.
+     * @see nextstep.subway.ui.LineController#createLine
+     */
+    @DisplayName("[예외]지하철 노선 하행 등록정보 없음 방지 테스트")
+    @Test
+    void 지하철_노선_하행_등록정보_없음_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_하행_정보없음);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
+    /**
+     * When 지하철 노선 생성을 요청 했을 때 노선 거리 정보가 없으면,
+     * Then 지하철 노선 생성이 실패한다.
+     * @see nextstep.subway.ui.LineController#createLine
+     */
+    @DisplayName("[예외]지하철 노선 거리 정보 없음 방지 테스트")
+    @Test
+    void 지하철_노선_거리_정보_없음_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_거리_정보없음);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
+    /**
+     * When 지하철 노선 생성을 요청 했을 때 상행역과 하행역이 같으면,
+     * Then 지하철 노선 생성이 실패한다.
+     * @see nextstep.subway.ui.LineController#createLine
+     */
+    @DisplayName("[예외]지하철 노선 상행 하행 중복 방지 테스트")
+    @Test
+    void 지하철_노선_상행_하행_중복_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_상행_하행_정보같음);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
     /**
@@ -60,7 +142,12 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_목록_조회_테스트() {
         // given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
         ApiUtil.지하철_노선_생성_API(GTXA노선);
+
+        ApiUtil.지하철역_생성_API(강남역);
+        ApiUtil.지하철역_생성_API(양재역);
         ApiUtil.지하철_노선_생성_API(신분당선);
 
         // when
@@ -83,6 +170,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_조회_테스트() {
         // given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
         ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
@@ -107,6 +196,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_수정_테스트() {
         // given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
         ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
@@ -131,7 +222,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선 삭제 테스트")
     @Test
     void 지하철_노선_삭제_테스트() {
-        // given
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
         ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
@@ -142,18 +235,66 @@ class LineAcceptanceTest extends AcceptanceTest {
     }
 
     static Map<String, String> GTXA노선;
+    static Map<String, String> GTXA노선_상행_정보없음;
+    static Map<String, String> GTXA노선_하행_정보없음;
+    static Map<String, String> GTXA노선_거리_정보없음;
+    static Map<String, String> GTXA노선_상행_하행_정보같음;
     static Map<String, String> 신분당선;
     static Map<String, String> 노선색상;
 
+    static Map<String, String> 연신내역;
+    static Map<String, String> 서울역;
+    static Map<String, String> 강남역;
+    static Map<String, String> 양재역;
+
     @BeforeAll
     public static void 초기화() {
+        연신내역 = new HashMap<>();
+        연신내역.put("name", "연신내");
+        서울역 = new HashMap<>();
+        서울역.put("name", "서울역");
+        강남역 = new HashMap<>();
+        강남역.put("name", "강남역");
+        양재역 = new HashMap<>();
+        양재역.put("name", "양재역");
+
         GTXA노선 = new HashMap<>();
         GTXA노선.put("name", "GTX-A");
         GTXA노선.put("color", "bg-red-900");
+        GTXA노선.put("upStationId", "1");
+        GTXA노선.put("downStationId", "2");
+        GTXA노선.put("distance", "10");
+
+        GTXA노선_상행_정보없음 = new HashMap<>();
+        GTXA노선_상행_정보없음.put("name", "GTX-A");
+        GTXA노선_상행_정보없음.put("color", "bg-red-900");
+        GTXA노선_상행_정보없음.put("downStationId", "2");
+        GTXA노선_상행_정보없음.put("distance", "10");
+
+        GTXA노선_하행_정보없음 = new HashMap<>();
+        GTXA노선_하행_정보없음.put("name", "GTX-A");
+        GTXA노선_하행_정보없음.put("color", "bg-red-900");
+        GTXA노선_하행_정보없음.put("upStationId", "1");
+        GTXA노선_하행_정보없음.put("distance", "10");
+
+        GTXA노선_거리_정보없음 = new HashMap<>();
+        GTXA노선_거리_정보없음.put("name", "GTX-A");
+        GTXA노선_거리_정보없음.put("color", "bg-red-900");
+        GTXA노선_거리_정보없음.put("upStationId", "1");
+        GTXA노선_거리_정보없음.put("downStationId", "2");
+
+        GTXA노선_상행_하행_정보같음 = new HashMap<>();
+        GTXA노선_상행_하행_정보같음.put("name", "GTX-A");
+        GTXA노선_상행_하행_정보같음.put("color", "bg-red-900");
+        GTXA노선_상행_하행_정보같음.put("upStationId", "1");
+        GTXA노선_상행_하행_정보같음.put("downStationId", "1");
 
         신분당선 = new HashMap<>();
         신분당선.put("name", "신분당선");
         신분당선.put("color", "bg-red-500");
+        신분당선.put("upStationId", "2");
+        신분당선.put("downStationId", "3");
+        신분당선.put("distance", "10");
 
         노선색상 = new HashMap<>();
         노선색상.put("color", "bg-red-800");

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -113,25 +113,6 @@ class LineAcceptanceTest extends AcceptanceTest {
     }
 
     /**
-     * When 지하철 노선 생성을 요청 했을 때 상행역과 하행역이 같으면,
-     * Then 지하철 노선 생성이 실패한다.
-     * @see nextstep.subway.ui.LineController#createLine
-     */
-    @DisplayName("[예외]지하철 노선 상행 하행 중복 방지 테스트")
-    @Test
-    void 지하철_노선_상행_하행_중복_방지_테스트() {
-        //given
-        ApiUtil.지하철역_생성_API(연신내역);
-        ApiUtil.지하철역_생성_API(서울역);
-
-        // when
-        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_상행_하행_정보같음);
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
-    }
-
-    /**
      * Given 지하철 노선 생성을 요청 하고
      * Given 새로운 지하철 노선 생성을 요청 하고
      * When 지하철 노선 목록 조회를 요청 하면

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -309,7 +309,7 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Given 지하철 노선 생성 및 노선 구간 생성을 하고,
      * When 생성한 지하철 노선 구간 삭제를 요청 하면
      * Then 생성한 지하철 노선 구간 삭제가 성공한다.
-     * @see nextstep.subway.ui.LineController#deleteSetion
+     * @see nextstep.subway.ui.LineController#deleteSection
      */
     @DisplayName("지하철 노선 구간 삭제 테스트")
     @Test

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -240,7 +240,6 @@ class LineAcceptanceTest extends AcceptanceTest {
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
     static Map<String, String> GTXA노선_거리_정보없음;
-    static Map<String, String> GTXA노선_상행_하행_정보같음;
     static Map<String, String> 신분당선;
     static Map<String, String> 노선색상;
 
@@ -289,13 +288,6 @@ class LineAcceptanceTest extends AcceptanceTest {
         GTXA노선_거리_정보없음.put("color", "bg-red-900");
         GTXA노선_거리_정보없음.put("upStationId", "1");
         GTXA노선_거리_정보없음.put("downStationId", "2");
-
-        GTXA노선_상행_하행_정보같음 = new HashMap<>();
-        GTXA노선_상행_하행_정보같음.put("name", "GTX-A");
-        GTXA노선_상행_하행_정보같음.put("color", "bg-red-900");
-        GTXA노선_상행_하행_정보같음.put("upStationId", "1");
-        GTXA노선_상행_하행_정보같음.put("downStationId", "1");
-        GTXA노선_상행_하행_정보같음.put("distance", "10");
 
         신분당선 = new HashMap<>();
         신분당선.put("name", "신분당선");

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,12 +1,11 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.utils.ApiUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
 import org.springframework.http.HttpStatus;
 import java.util.HashMap;
 import java.util.List;
@@ -15,7 +14,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
-
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
@@ -25,7 +23,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_생성_테스트() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_API(GTXA노선);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -42,10 +40,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_이름_중복_생성_방지_테스트() {
         // given
-        지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_API(GTXA노선);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
@@ -62,11 +60,11 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_목록_조회_테스트() {
         // given
-        지하철_노선_생성_API(GTXA노선);
-        지하철_노선_생성_API(신분당선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(신분당선);
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선_전체_리스트_조회_API();
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_전체_리스트_조회_API();
 
         // then
         List<String> lineNames = response.body().jsonPath().getList("name");
@@ -85,10 +83,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_조회_테스트() {
         // given
-        지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선_단건_조회_API(1L);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_단건_조회_API(1L);
 
         // then
         String lineName = response.body().jsonPath().get("name").toString();
@@ -109,13 +107,13 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_수정_테스트() {
         // given
-        지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선_수정_API(1L, 노선색상);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_수정_API(1L, 노선색상);
 
         // then
-        ExtractableResponse<Response> updatedLine = 지하철_노선_단건_조회_API(1L);
+        ExtractableResponse<Response> updatedLine = ApiUtil.지하철_노선_단건_조회_API(1L);
         String lineName = updatedLine.body().jsonPath().get("name").toString();
         String lineColor = updatedLine.body().jsonPath().get("color").toString();
 
@@ -134,10 +132,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철_노선_삭제_테스트() {
         // given
-        지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선);
 
         // when
-        ExtractableResponse<Response> deleteResponse = 지하철_노선_삭제_API(1L);
+        ExtractableResponse<Response> deleteResponse = ApiUtil.지하철_노선_삭제_API(1L);
 
         // then
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -159,55 +157,5 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         노선색상 = new HashMap<>();
         노선색상.put("color", "bg-red-800");
-    }
-
-    ExtractableResponse<Response> 지하철_노선_생성_API(Map<String, String> params) {
-        return RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/lines")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_전체_리스트_조회_API() {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/lines")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_단건_조회_API(Long id) {
-        return RestAssured.given().log().all()
-                .pathParam("id", id)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .get("/lines/{id}")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_수정_API(Long id, Map<String, String> updateParams) {
-        return RestAssured.given().log().all()
-                .pathParam("id", id)
-                .body(updateParams)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .put("/lines/{id}")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철_노선_삭제_API(Long id) {
-        return RestAssured.given().log().all()
-                .pathParam("id", id)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .delete("/lines/{id}")
-                .then().log().all()
-                .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -351,6 +351,27 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
+    /**
+     * Given 지하철 노선 생성 및 노선 구간 생성을 하고,
+     * When 하행 종점이 아닌 지하철 노선 구간 삭제를 요청 하면
+     * Then 생성한 지하철 노선 구간 삭제가 실패한다.
+     * @see nextstep.subway.ui.LineController#deleteSection
+     */
+    @DisplayName("지하철 노선 한 구간만 존재할 경우 삭제 방지 테스트")
+    @Test
+    void 지하철_노선_한_구간만_존재할_경우_삭제_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
+
+        // when
+        ExtractableResponse<Response> deleteResponse = ApiUtil.지하철_노선_구간_삭제_API(1L, GTXA노선_구간_삭제_서울역);
+
+        // then
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
     static Map<String, String> GTXA노선_연신내_서울역;
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
@@ -370,6 +391,7 @@ class LineAcceptanceTest extends AcceptanceTest {
 
     static Map<String, String> GTXA노선_구간_삭제_삼성역;
     static Map<String, String> GTXA노선_구간_삭제_연신내;
+    static Map<String, String> GTXA노선_구간_삭제_서울역;
 
     @BeforeAll
     public static void 초기화() {
@@ -440,5 +462,8 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         GTXA노선_구간_삭제_연신내 = new HashMap<>();
         GTXA노선_구간_삭제_연신내.put("stationId", "1");
+
+        GTXA노선_구간_삭제_서울역 = new HashMap<>();
+        GTXA노선_구간_삭제_서울역.put("stationId", "2");
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,17 +1,43 @@
 package nextstep.subway.acceptance;
 
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.HttpStatus;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
     /**
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
+     * @see nextstep.subway.ui.LineController#createLine
      */
-    @DisplayName("지하철 노선 생성")
     @Test
-    void createLine() {
+    void 지하철_노선_생성_테스트() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "GTX-A");
+        params.put("color", "bg-red-900");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
     }
 
     /**
@@ -19,39 +45,171 @@ class LineAcceptanceTest extends AcceptanceTest {
      * Given 새로운 지하철 노선 생성을 요청 하고
      * When 지하철 노선 목록 조회를 요청 하면
      * Then 두 노선이 포함된 지하철 노선 목록을 응답받는다
+     * @see nextstep.subway.ui.LineController#findAllLines()
      */
-    @DisplayName("지하철 노선 목록 조회")
     @Test
-    void getLines() {
+    void 지하철_노선_목록_조회_테스트() {
+        Map<String, String> gtxALineParams = new HashMap<>();
+        gtxALineParams.put("name", "GTX-A");
+        gtxALineParams.put("color", "bg-red-900");
+
+        Map<String, String> shinbundangLineParams = new HashMap<>();
+        shinbundangLineParams.put("name", "신분당선");
+        shinbundangLineParams.put("color", "bg-red-500");
+
+        // given
+        RestAssured.given().log().all()
+                .body(gtxALineParams)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        RestAssured.given().log().all()
+                .body(shinbundangLineParams)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // when
+        ExtractableResponse<Response> lines = RestAssured.given().log().all()
+                .params(new HashMap<>())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines")
+                .then().log().all()
+                .extract();
+
+        // then
+        List<String> lineNames = lines.body().jsonPath().getList("name");
+
+        assertThat(lines.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(lineNames).contains("신분당선", "GTX-A");
     }
 
     /**
      * Given 지하철 노선 생성을 요청 하고
      * When 생성한 지하철 노선 조회를 요청 하면
      * Then 생성한 지하철 노선을 응답받는다
+     * @see nextstep.subway.ui.LineController#getLine
      */
-    @DisplayName("지하철 노선 조회")
     @Test
-    void getLine() {
+    void 지하철_노선_조회_테스트() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "GTX-A");
+        params.put("color", "bg-red-900");
+
+        // given
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .pathParam("id", 1L)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines/{id}")
+                .then().log().all()
+                .extract();
+
+        // then
+        String lineName = response.body().jsonPath().get("name").toString();
+        String lineColor = response.body().jsonPath().get("color").toString();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(lineName).isEqualTo("GTX-A");
+        assertThat(lineColor).isEqualTo("bg-red-900");
     }
 
     /**
      * Given 지하철 노선 생성을 요청 하고
      * When 지하철 노선의 정보 수정을 요청 하면
      * Then 지하철 노선의 정보 수정은 성공한다.
+     * @see nextstep.subway.ui.LineController#updateLine
      */
-    @DisplayName("지하철 노선 수정")
     @Test
-    void updateLine() {
+    void 지하철_노선_수정_테스트() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "GTX-A");
+        params.put("color", "bg-red-900");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        Map<String, String> updateParams = new HashMap<>();
+        updateParams.put("color", "bg-red-800");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured.given().log().all()
+                .pathParam("id", 1L)
+                .body(updateParams)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put("/lines/{id}")
+                .then().log().all()
+                .extract();
+
+        // then
+        ExtractableResponse<Response> updatedLine = RestAssured.given().log().all()
+                .pathParam("id", 1L)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines/{id}")
+                .then().log().all()
+                .extract();
+        String lineName = updatedLine.body().jsonPath().get("name").toString();
+        String lineColor = updatedLine.body().jsonPath().get("color").toString();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(lineName).isEqualTo("GTX-A");
+        assertThat(lineColor).isEqualTo("bg-red-800");
     }
 
     /**
      * Given 지하철 노선 생성을 요청 하고
      * When 생성한 지하철 노선 삭제를 요청 하면
      * Then 생성한 지하철 노선 삭제가 성공한다.
+     * @see nextstep.subway.ui.LineController#deleteLine
      */
-    @DisplayName("지하철 노선 삭제")
     @Test
-    void deleteLine() {
+    void 지하철_노선_삭제_테스트() {
+        // given
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "GTX-A");
+        params.put("color", "bg-red-900");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+
+        // when
+        ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()
+                .pathParam("id", 1L)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/lines/{id}")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -257,6 +257,27 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
     }
 
+    /**
+     * When 지하철 노선 구간 생성을 요청 시, 하행역이 이미 존재할 경우,
+     * Then 지하철 노선 구건 생성에 실패한다.
+     * @see nextstep.subway.ui.LineController#createSection
+     */
+    @DisplayName("[예외]지하철 노선 구간 생성 시 하행역이 이미 존재함 방지 테스트")
+    @Test
+    void 지하철_노선_구간_생성_시_하행역이_이미_존재_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+        ApiUtil.지하철역_생성_API(삼성역);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간_서울역_연신내역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
     static Map<String, String> GTXA노선_연신내_서울역;
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
@@ -272,6 +293,7 @@ class LineAcceptanceTest extends AcceptanceTest {
 
     static Map<String, String> GTXA노선_구간_서울역_삼성역;
     static Map<String, String> GTXA노선_구간_연신내역_삼성역;
+    static Map<String, String> GTXA노선_구간_서울역_연신내역;
 
     @BeforeAll
     public static void 초기화() {
@@ -331,5 +353,10 @@ class LineAcceptanceTest extends AcceptanceTest {
         GTXA노선_구간_연신내역_삼성역.put("upStationId", "1");
         GTXA노선_구간_연신내역_삼성역.put("downStationId", "3");
         GTXA노선_구간_연신내역_삼성역.put("distance", "10");
+
+        GTXA노선_구간_서울역_연신내역 = new HashMap<>();
+        GTXA노선_구간_서울역_연신내역.put("upStationId", "2");
+        GTXA노선_구간_서울역_연신내역.put("downStationId", "1");
+        GTXA노선_구간_서울역_연신내역.put("distance", "10");
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -27,7 +27,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         ApiUtil.지하철역_생성_API(서울역);
 
         // when
-        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -46,10 +46,10 @@ class LineAcceptanceTest extends AcceptanceTest {
         //given
         ApiUtil.지하철역_생성_API(연신내역);
         ApiUtil.지하철역_생성_API(서울역);
-        ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // when
-        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
@@ -125,7 +125,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         ApiUtil.지하철역_생성_API(연신내역);
         ApiUtil.지하철역_생성_API(서울역);
-        ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         ApiUtil.지하철역_생성_API(강남역);
         ApiUtil.지하철역_생성_API(양재역);
@@ -153,7 +153,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         ApiUtil.지하철역_생성_API(연신내역);
         ApiUtil.지하철역_생성_API(서울역);
-        ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // when
         ExtractableResponse<Response> response = ApiUtil.지하철_노선_단건_조회_API(1L);
@@ -179,7 +179,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         ApiUtil.지하철역_생성_API(연신내역);
         ApiUtil.지하철역_생성_API(서울역);
-        ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // when
         ExtractableResponse<Response> response = ApiUtil.지하철_노선_수정_API(1L, 노선색상);
@@ -206,7 +206,7 @@ class LineAcceptanceTest extends AcceptanceTest {
         //given
         ApiUtil.지하철역_생성_API(연신내역);
         ApiUtil.지하철역_생성_API(서울역);
-        ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // when
         ExtractableResponse<Response> deleteResponse = ApiUtil.지하철_노선_삭제_API(1L);
@@ -227,16 +227,37 @@ class LineAcceptanceTest extends AcceptanceTest {
         ApiUtil.지하철역_생성_API(연신내역);
         ApiUtil.지하철역_생성_API(서울역);
         ApiUtil.지하철역_생성_API(삼성역);
-        ApiUtil.지하철_노선_생성_API(GTXA노선);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
 
         // when
-        ExtractableResponse<Response> response = ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간);
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간_서울역_삼성역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
 
-    static Map<String, String> GTXA노선;
+    /**
+     * When 지하철 노선 구간 생성을 요청 시, 상행역은 해당 노선에 등록되어있는 하행역 아니면,
+     * Then 지하철 노선 구건 생성에 실패한다.
+     * @see nextstep.subway.ui.LineController#createSection
+     */
+    @DisplayName("[예외]지하철 노선 구간 생성 시 기존 역의 하행역이 아닐경우 방지 테스트")
+    @Test
+    void 지하철_노선_구간_생성_시_기존_역의_하행역이_아닐경우_방지_테스트() {
+        //given
+        ApiUtil.지하철역_생성_API(연신내역);
+        ApiUtil.지하철역_생성_API(서울역);
+        ApiUtil.지하철역_생성_API(삼성역);
+        ApiUtil.지하철_노선_생성_API(GTXA노선_연신내_서울역);
+
+        // when
+        ExtractableResponse<Response> response = ApiUtil.지하철_노선_구간_등록_API(1L, GTXA노선_구간_연신내역_삼성역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    static Map<String, String> GTXA노선_연신내_서울역;
     static Map<String, String> GTXA노선_상행_정보없음;
     static Map<String, String> GTXA노선_하행_정보없음;
     static Map<String, String> GTXA노선_거리_음수;
@@ -249,7 +270,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     static Map<String, String> 강남역;
     static Map<String, String> 양재역;
 
-    static Map<String, String> GTXA노선_구간;
+    static Map<String, String> GTXA노선_구간_서울역_삼성역;
+    static Map<String, String> GTXA노선_구간_연신내역_삼성역;
 
     @BeforeAll
     public static void 초기화() {
@@ -264,12 +286,12 @@ class LineAcceptanceTest extends AcceptanceTest {
         양재역 = new HashMap<>();
         양재역.put("name", "양재역");
 
-        GTXA노선 = new HashMap<>();
-        GTXA노선.put("name", "GTX-A");
-        GTXA노선.put("color", "bg-red-900");
-        GTXA노선.put("upStationId", "1");
-        GTXA노선.put("downStationId", "2");
-        GTXA노선.put("distance", "10");
+        GTXA노선_연신내_서울역 = new HashMap<>();
+        GTXA노선_연신내_서울역.put("name", "GTX-A");
+        GTXA노선_연신내_서울역.put("color", "bg-red-900");
+        GTXA노선_연신내_서울역.put("upStationId", "1");
+        GTXA노선_연신내_서울역.put("downStationId", "2");
+        GTXA노선_연신내_서울역.put("distance", "10");
 
         GTXA노선_상행_정보없음 = new HashMap<>();
         GTXA노선_상행_정보없음.put("name", "GTX-A");
@@ -300,9 +322,14 @@ class LineAcceptanceTest extends AcceptanceTest {
         노선색상 = new HashMap<>();
         노선색상.put("color", "bg-red-800");
 
-        GTXA노선_구간 = new HashMap<>();
-        GTXA노선_구간.put("upStationId", "2");
-        GTXA노선_구간.put("downStationId", "3");
-        GTXA노선_구간.put("distance", "10");
+        GTXA노선_구간_서울역_삼성역 = new HashMap<>();
+        GTXA노선_구간_서울역_삼성역.put("upStationId", "2");
+        GTXA노선_구간_서울역_삼성역.put("downStationId", "3");
+        GTXA노선_구간_서울역_삼성역.put("distance", "10");
+
+        GTXA노선_구간_연신내역_삼성역 = new HashMap<>();
+        GTXA노선_구간_연신내역_삼성역.put("upStationId", "1");
+        GTXA노선_구간_연신내역_삼성역.put("downStationId", "3");
+        GTXA노선_구간_연신내역_삼성역.put("distance", "10");
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -47,7 +47,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = ApiUtil.지하철역_생성_API(강남역);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,13 +1,12 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.utils.ApiUtil;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +24,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void createStation() {
         // when
-        ExtractableResponse<Response> response = 지하철역_생성_API(강남역);
+        ExtractableResponse<Response> response = ApiUtil.지하철역_생성_API(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -42,10 +41,10 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철역_이름_중복_생성_방지_테스트() {
         // given
-        지하철역_생성_API(강남역);
+        ApiUtil.지하철역_생성_API(강남역);
 
         // when
-        ExtractableResponse<Response> response = 지하철역_생성_API(강남역);
+        ExtractableResponse<Response> response = ApiUtil.지하철역_생성_API(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
@@ -61,11 +60,11 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void getStations() {
         /// given
-        지하철역_생성_API(강남역);
-        지하철역_생성_API(역삼역);
+        ApiUtil.지하철역_생성_API(강남역);
+        ApiUtil.지하철역_생성_API(역삼역);
 
         // when
-        ExtractableResponse<Response> response = 지하철역_전체_리스트_조회_API();
+        ExtractableResponse<Response> response = ApiUtil.지하철역_전체_리스트_조회_API();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         List<String> stationNames = response.jsonPath().getList("name");
@@ -81,11 +80,11 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철역_생성_API(강남역);
+        ExtractableResponse<Response> createResponse = ApiUtil.지하철역_생성_API(강남역);
 
         // when
         String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = 지하철역_삭제_API(uri);
+        ExtractableResponse<Response> response = ApiUtil.지하철역_삭제_API(uri);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -101,31 +100,5 @@ class StationAcceptanceTest extends AcceptanceTest {
 
         역삼역 = new HashMap<>();
         역삼역.put("name", "역삼역");
-    }
-
-    ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {
-        return RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post("/stations")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철역_전체_리스트_조회_API() {
-        return RestAssured.given().log().all()
-                .when()
-                .get("/stations")
-                .then().log().all()
-                .extract();
-    }
-
-    ExtractableResponse<Response> 지하철역_삭제_API(String uri) {
-        return RestAssured.given().log().all()
-                .when()
-                .delete(uri)
-                .then().log().all()
-                .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -65,7 +65,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         지하철역_생성_API(역삼역);
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선_전체_리스트_조회_API();
+        ExtractableResponse<Response> response = 지하철역_전체_리스트_조회_API();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         List<String> stationNames = response.jsonPath().getList("name");
@@ -85,7 +85,7 @@ class StationAcceptanceTest extends AcceptanceTest {
 
         // when
         String uri = createResponse.header("Location");
-        ExtractableResponse<Response> response = 지하철_노선_삭제_API(uri);
+        ExtractableResponse<Response> response = 지하철역_삭제_API(uri);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
@@ -113,7 +113,7 @@ class StationAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
-    ExtractableResponse<Response> 지하철_노선_전체_리스트_조회_API() {
+    ExtractableResponse<Response> 지하철역_전체_리스트_조회_API() {
         return RestAssured.given().log().all()
                 .when()
                 .get("/stations")
@@ -121,7 +121,7 @@ class StationAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
-    ExtractableResponse<Response> 지하철_노선_삭제_API(String uri) {
+    ExtractableResponse<Response> 지하철역_삭제_API(String uri) {
         return RestAssured.given().log().all()
                 .when()
                 .delete(uri)

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -23,11 +24,8 @@ class StationAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철역 생성")
     @Test
     void createStation() {
-        // given
-        Map<String, String> params = 파라미터_생성("강남역");
-
         // when
-        ExtractableResponse<Response> response = 지하철역_생성_API(params);
+        ExtractableResponse<Response> response = 지하철역_생성_API(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -44,11 +42,10 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void 지하철역_이름_중복_생성_방지_테스트() {
         // given
-        String 강남역 = "강남역";
-        지하철역_생성(강남역);
+        지하철역_생성_API(강남역);
 
         // when
-        ExtractableResponse<Response> response = 지하철역_생성(강남역);
+        ExtractableResponse<Response> response = 지하철역_생성_API(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
@@ -64,18 +61,15 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void getStations() {
         /// given
-        String 강남역 = "강남역";
-        지하철역_생성(강남역);
-
-        String 역삼역 = "역삼역";
-        지하철역_생성(역삼역);
+        지하철역_생성_API(강남역);
+        지하철역_생성_API(역삼역);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_전체_리스트_조회_API();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         List<String> stationNames = response.jsonPath().getList("name");
-        assertThat(stationNames).contains(강남역, 역삼역);
+        assertThat(stationNames).contains("강남역", "역삼역");
     }
 
     /**
@@ -87,7 +81,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철역_생성("강남역");
+        ExtractableResponse<Response> createResponse = 지하철역_생성_API(강남역);
 
         // when
         String uri = createResponse.header("Location");
@@ -97,17 +91,16 @@ class StationAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
-    Map<String, String> 파라미터_생성(String 지하철역명) {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", 지하철역명);
+    static Map<String, String> 강남역;
+    static Map<String, String> 역삼역;
 
-        return params;
-    }
+    @BeforeAll
+    public static void 초기화() {
+        강남역 = new HashMap<>();
+        강남역.put("name", "강남역");
 
-    ExtractableResponse<Response> 지하철역_생성(String 지하철역명) {
-        Map<String, String> params = 파라미터_생성(지하철역명);
-
-        return 지하철역_생성_API(params);
+        역삼역 = new HashMap<>();
+        역삼역.put("name", "역삼역");
     }
 
     ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {

--- a/src/test/java/nextstep/subway/utils/ApiUtil.java
+++ b/src/test/java/nextstep/subway/utils/ApiUtil.java
@@ -69,6 +69,17 @@ public class ApiUtil {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 지하철_노선_구간_삭제_API(Long id, Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/lines/{id}/sections")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {
         return RestAssured.given().log().all()
                 .body(params)

--- a/src/test/java/nextstep/subway/utils/ApiUtil.java
+++ b/src/test/java/nextstep/subway/utils/ApiUtil.java
@@ -1,0 +1,87 @@
+package nextstep.subway.utils;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class ApiUtil {
+    public static ExtractableResponse<Response> 지하철_노선_생성_API(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_전체_리스트_조회_API() {
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_단건_조회_API(Long id) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .get("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_수정_API(Long id, Map<String, String> updateParams) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .body(updateParams)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_삭제_API(Long id) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철역_전체_리스트_조회_API() {
+        return RestAssured.given().log().all()
+                .when()
+                .get("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철역_삭제_API(String uri) {
+        return RestAssured.given().log().all()
+                .when()
+                .delete(uri)
+                .then().log().all()
+                .extract();
+    }
+
+}

--- a/src/test/java/nextstep/subway/utils/ApiUtil.java
+++ b/src/test/java/nextstep/subway/utils/ApiUtil.java
@@ -64,7 +64,7 @@ public class ApiUtil {
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .post("/lines/{id}/section")
+                .post("/lines/{id}/sections")
                 .then().log().all()
                 .extract();
     }
@@ -72,7 +72,7 @@ public class ApiUtil {
     public static ExtractableResponse<Response> 지하철_노선_구간_삭제_API(Long id, Map<String, String> params) {
         return RestAssured.given().log().all()
                 .pathParam("id", id)
-                .body(params)
+                .params(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .delete("/lines/{id}/sections")

--- a/src/test/java/nextstep/subway/utils/ApiUtil.java
+++ b/src/test/java/nextstep/subway/utils/ApiUtil.java
@@ -64,7 +64,7 @@ public class ApiUtil {
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
-                .delete("/lines/{id}/section")
+                .post("/lines/{id}/section")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/nextstep/subway/utils/ApiUtil.java
+++ b/src/test/java/nextstep/subway/utils/ApiUtil.java
@@ -58,6 +58,17 @@ public class ApiUtil {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 지하철_노선_구간_등록_API(Long id, Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .pathParam("id", id)
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .delete("/lines/{id}/section")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 지하철역_생성_API(Map<String, String> params) {
         return RestAssured.given().log().all()
                 .body(params)


### PR DESCRIPTION
[요구사항]
지하철 노선 생성 시 필요한 인자 추가하기
지하철 노선에 구간을 등록하는 기능 구현
지하철 노선에 구간을 제거하는 기능 구현
지하철 노선에 등록된 구간을 통해 역 목록을 조회하는 기능 구현
구간 등록 / 제거 시 예외 케이스에 대한 인수 테스트 작성

[질문내용]
1. // given영역 지하철역_생성_API의 경우 테스트와 전혀 무관한 API요청이라 DB에 직접 insert해도 되지 않을까요?
2. 생성 테스트의 경우 이 정도만 확인해도 될까? DB의 내용을 확인해보지 않아도 될까? 예) updateAt과 createAt을 반대로 저장하고있다면?
 JAVA, JPA를 사용해본적이 없어서 정확한 동작을 파악하기 힘들고, 업데이트, 삭제의 경우는 반환값도 없기 떄문에 오류가 발생하지 않으면, 테스트 코드가 통과할것 같습니다. ㅜ,ㅜ

3. 테스트에서 id 값을 컨트롤 할 필요는 있지 않나생각이 됩니다. 예를들어) 테스트코드 짤때, 생성요청 순서를 기억하고 있어야함.