### PR TITLE
1주차 3단계 - 지하철 구간 관리

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -5,6 +5,8 @@ import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.common.exception.DuplicateAttributeException;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,22 +16,42 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class LineService {
-    private LineRepository lineRepository;
+    private final LineRepository lineRepository;
 
-    public LineService(LineRepository lineRepository) {
+    private final StationRepository stationRepository;
+
+    public LineService(
+            final LineRepository lineRepository,
+            final StationRepository stationRepository
+    ) {
         this.lineRepository = lineRepository;
+        this.stationRepository = stationRepository;
     }
 
-    public LineResponse saveLine(LineRequest request) {
+    public LineResponse createLine(LineRequest request) {
         var requestName = request.getName();
         var requestColor = request.getColor();
+        var requestUpStationId = request.getUpStationId();
+        var requestDownStationId = request.getDownStationId();
+        var distance = request.getDistance();
 
         if (isLineNamePresent(requestName)) {
             throw new DuplicateAttributeException("이미 존재하는 노선 명: " + requestName);
         }
 
-        Line line = lineRepository.save(new Line(requestName, requestColor));
-        return LineResponse.of(line);
+        var section = new Section(
+                stationRepository.findById(requestUpStationId).orElseThrow(),
+                stationRepository.findById(requestDownStationId).orElseThrow(),
+                distance
+        );
+
+        var line = new Line(requestName, requestColor);
+        Line savedLine = lineRepository.save(line);
+
+        section.setLine(savedLine);
+        line.getSections().add(section);
+
+        return LineResponse.of(savedLine);
     }
 
     public void deleteLineById(Long id) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -41,16 +41,15 @@ public class LineService {
         }
 
         var section = new Section(
-                stationRepository.findById(requestUpStationId).orElseThrow(),
-                stationRepository.findById(requestDownStationId).orElseThrow(),
+                stationRepository.findById(requestUpStationId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + requestUpStationId)),
+                stationRepository.findById(requestDownStationId)
+                        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + requestDownStationId)),
                 distance
         );
 
-        var line = new Line(requestName, requestColor);
-        Line savedLine = lineRepository.save(line);
-
-        section.setLine(savedLine);
-        line.getSections().add(section);
+        var savedLine = lineRepository.save(new Line(requestName, requestColor));
+        savedLine.init(section);
 
         return LineResponse.of(savedLine);
     }
@@ -93,7 +92,7 @@ public class LineService {
         var distance = sectionRequest.getDistance();
 
         var upStation = stationRepository.findById(upStationId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + upStationId ));
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + upStationId));
         var downStation = stationRepository.findById(sectionRequest.getDownStationId())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + downStationId));
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -84,9 +84,9 @@ public class LineService {
         return LineResponse.of(line);
     }
 
-    public void addStationToLine(Long lienId, SectionRequest sectionRequest) {
-        var line = lineRepository.findById(lienId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + lienId));
+    public void addStationToLine(Long lineId, SectionRequest sectionRequest) {
+        var line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + lineId));
 
         var upStationId = sectionRequest.getUpStationId();
         var downStationId = sectionRequest.getDownStationId();
@@ -100,6 +100,16 @@ public class LineService {
         var section = new Section(upStation, downStation, distance);
         section.setLine(line);
         line.addSection(section);
+    }
+
+    public void popStationToLine(Long lineId, Long stationId) {
+        var line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + lineId));
+
+        var station = stationRepository.findById(stationId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + stationId));
+
+        line.remove(station);
     }
 
     private boolean isLineNamePresent(String lineName) {

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -2,6 +2,7 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.common.exception.DuplicateAttributeException;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
@@ -81,6 +82,24 @@ public class LineService {
         line.update(lineRequest.getName(), lineRequest.getColor());
 
         return LineResponse.of(line);
+    }
+
+    public void addStationToLine(Long lienId, SectionRequest sectionRequest) {
+        var line = lineRepository.findById(lienId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 노선 id: " + lienId));
+
+        var upStationId = sectionRequest.getUpStationId();
+        var downStationId = sectionRequest.getDownStationId();
+        var distance = sectionRequest.getDistance();
+
+        var upStation = stationRepository.findById(upStationId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + upStationId ));
+        var downStation = stationRepository.findById(sectionRequest.getDownStationId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 지하철 역 id: " + downStationId));
+
+        var section = new Section(upStation, downStation, distance);
+        section.setLine(line);
+        line.addSection(section);
     }
 
     private boolean isLineNamePresent(String lineName) {

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -3,6 +3,9 @@ package nextstep.subway.applicaion.dto;
 public class LineRequest {
     private String name;
     private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
 
     public String getName() {
         return name;
@@ -10,5 +13,17 @@ public class LineRequest {
 
     public String getColor() {
         return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,20 +1,31 @@
 package nextstep.subway.applicaion.dto;
 
 import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class LineResponse {
     private Long id;
     private String name;
     private String color;
+    private List<StationResponse> stations;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
-    public LineResponse(Long id, String name, String color, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+    private LineResponse(
+            Long id,
+            String name,
+            String color,
+            List<StationResponse> stations,
+            LocalDateTime createdDate,
+            LocalDateTime modifiedDate) {
         this.id = id;
         this.name = name;
         this.color = color;
+        this.stations = stations;
         this.createdDate = createdDate;
         this.modifiedDate = modifiedDate;
     }
@@ -31,6 +42,10 @@ public class LineResponse {
         return color;
     }
 
+    public List<StationResponse> getStations() {
+        return stations;
+    }
+
     public LocalDateTime getCreatedDate() {
         return createdDate;
     }
@@ -40,10 +55,19 @@ public class LineResponse {
     }
 
     public static LineResponse of(Line line) {
+        var sections = line.getSections();
+
+        var stationResponses = sections.stream()
+                .map(Section::getUpStation)
+                .map(StationResponse::of)
+                .collect(Collectors.toList());
+        stationResponses.add(StationResponse.of(sections.get(sections.size() - 1).getDownStation()));
+
         return new LineResponse(
                 line.getId(),
                 line.getName(),
                 line.getColor(),
+                stationResponses,
                 line.getCreatedDate(),
                 line.getModifiedDate()
         );

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -1,0 +1,22 @@
+package nextstep.subway.applicaion.dto;
+
+public class SectionRequest {
+
+    private Long downStationId;
+
+    private Long upStationId;
+
+    private int distance;
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -59,6 +59,11 @@ public class Line extends BaseEntity {
         sections.add(section);
     }
 
+    public void remove(Station station) {
+        verifyCanBeDeleted(station);
+        sections.remove(sections.size() - 1);
+    }
+
     private void verifyCanBeAdded(Section section) {
         if (sections.isEmpty()) {
             throw new IllegalArgumentException("비어있는 노선에 구간을 추가할 수 없습니다.");
@@ -73,6 +78,16 @@ public class Line extends BaseEntity {
         if (sections.stream().map(Section::getUpStation).anyMatch(station -> station.equals(downStation))
                 || sections.stream().map(Section::getDownStation).anyMatch(station -> station.equals(downStation))) {
             throw new IllegalArgumentException("새로운 구간의 하행역이 해당 노선에 이미 등록되어있습니다.");
+        }
+    }
+
+    private void verifyCanBeDeleted(Station station) {
+        if (sections.size() <= 1) {
+            throw new IllegalStateException("노선에 구간이 부족하여 역을 삭제할 수 없습니다.");
+        }
+
+        if (!sections.get(sections.size() - 1).getDownStation().equals(station)) {
+            throw new IllegalArgumentException("삭제하려는 역은 해당 노선 마지막 구간의 하행역이 아닙니다.");
         }
     }
 

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -2,6 +2,7 @@ package nextstep.subway.domain;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -45,12 +46,17 @@ public class Line extends BaseEntity {
     }
 
     public List<Section> getSections() {
-        return sections;
+        return Collections.unmodifiableList(sections);
     }
 
     public void update(String name, String color) {
         this.name = name;
         this.color = color;
+    }
+
+    public void init(Section section) {
+        section.setLine(this);
+        sections.add(section);
     }
 
     public void addSection(Section section) {

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,0 +1,63 @@
+package nextstep.subway.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class Section {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "line_id")
+    private Line line;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "up_station_id")
+    private Station upStation;
+
+    @ManyToOne(cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "down_station_id")
+    private Station downStation;
+
+    private int distance;
+
+    protected Section() {
+    }
+
+    public Section(
+            Station upStation,
+            Station downStation,
+            int distance
+    ) {
+        this.upStation = upStation;
+        this.downStation = downStation;
+        this.distance = distance;
+    }
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public Line getLine() {
+        return line;
+    }
+
+    public Station getUpStation() {
+        return upStation;
+    }
+
+    public Station getDownStation() {
+        return downStation;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+
+    public void setLine(Line line) {
+        this.line = line;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -4,6 +4,7 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import java.util.Objects;
 
 @Entity
 public class Station extends BaseEntity {
@@ -25,5 +26,18 @@ public class Station extends BaseEntity {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Station)) return false;
+        Station station = (Station) o;
+        return Objects.equals(id, station.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -62,5 +62,14 @@ public class LineController {
         lineService.addStationToLine(lineId, sectionRequest);
     }
 
+    @DeleteMapping("/{lineId}/sections")
+    @ResponseStatus(HttpStatus.OK)
+    public void removeLineStation(
+            @PathVariable Long lineId,
+            @RequestParam Long stationId
+    ) {
+        lineService.popStationToLine(lineId, stationId);
+    }
+
 
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -3,6 +3,7 @@ package nextstep.subway.ui;
 import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,7 +22,7 @@ public class LineController {
 
     @PostMapping
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
-        LineResponse line = lineService.saveLine(lineRequest);
+        LineResponse line = lineService.createLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
     }
 
@@ -51,5 +52,15 @@ public class LineController {
     ) {
         return lineService.updateLine(id, lineRequest);
     }
+
+    @PostMapping("/{lineId}/sections")
+    @ResponseStatus(HttpStatus.OK)
+    public void createLineStation(
+            @PathVariable Long lineId,
+            @RequestBody SectionRequest sectionRequest
+    ) {
+        lineService.addStationToLine(lineId, sectionRequest);
+    }
+
 
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -2,8 +2,10 @@ package nextstep.subway.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.acceptance.step.StationStep;
 import nextstep.subway.fixture.LineFixture;
 import nextstep.subway.acceptance.step.LineStep;
+import nextstep.subway.fixture.StationFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -24,6 +26,11 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine() {
         // given
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        StationStep.역_생성_요청(station1);
+        StationStep.역_생성_요청(station2);
+
         var params = LineFixture.신분당선;
 
         // when
@@ -43,11 +50,18 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        var params1 = LineFixture.신분당선;
-        var createResponse1 = LineStep.노선_생성_요청(params1);
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        var station3 = StationFixture.역삼역;
+        StationStep.역_생성_요청(station1);
+        StationStep.역_생성_요청(station2);
+        StationStep.역_생성_요청(station3);
 
-        var params2 = LineFixture.구분당선;
-        var createResponse2 = LineStep.노선_생성_요청(params2);
+        var params1 = LineFixture.신분당선;
+        LineStep.노선_생성_요청(params1);
+
+        var params2 = LineFixture.이호선;
+        LineStep.노선_생성_요청(params2);
 
         // when
         var response = LineStep.노선_목록_조회_요청();
@@ -65,6 +79,11 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        StationStep.역_생성_요청(station1);
+        StationStep.역_생성_요청(station2);
+
         var params = LineFixture.신분당선;
         var createResponse = LineStep.노선_생성_요청(params);
 
@@ -85,11 +104,16 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine() {
         // given
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        StationStep.역_생성_요청(station1);
+        StationStep.역_생성_요청(station2);
+
         var params = LineFixture.신분당선;
         var createResponse = LineStep.노선_생성_요청(params);
 
         // when
-        var modifyParams = LineFixture.구분당선;
+        var modifyParams = LineFixture.이호선;
 
         var uri = createResponse.header("Location");
         var response = LineStep.노선_수정_요청(uri, modifyParams);
@@ -107,6 +131,11 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        StationStep.역_생성_요청(station1);
+        StationStep.역_생성_요청(station2);
+
         var params = LineFixture.신분당선;
         var createResponse = LineStep.노선_생성_요청(params);
 
@@ -127,6 +156,11 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLineWithDuplicateName() {
         // given
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        StationStep.역_생성_요청(station1);
+        StationStep.역_생성_요청(station2);
+
         var params = LineFixture.신분당선;
         var createResponse = LineStep.노선_생성_요청(params);
 
@@ -142,19 +176,19 @@ class LineAcceptanceTest extends AcceptanceTest {
         assertThat(response.header("Location")).isNotBlank();
     }
 
-    private void 노선_목록_조회_완료(ExtractableResponse<Response> response, Map<String, String>... paramsArgs) {
+    private void 노선_목록_조회_완료(ExtractableResponse<Response> response, Map<String, Object>... paramsArgs) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         var lineNames = response.jsonPath().getList("name");
         assertThat(lineNames).contains(Arrays.stream(paramsArgs).map(m -> m.get("name")).toArray());
     }
 
-    private void 노선_조회_완료(ExtractableResponse<Response> response, Map<String, String> params) {
+    private void 노선_조회_완료(ExtractableResponse<Response> response, Map<String, Object> params) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         var lineName = response.jsonPath().getString("name");
         assertThat(lineName).isEqualTo(params.get("name"));
     }
 
-    private void 노선_수정_완료(ExtractableResponse<Response> response, Map<String, String> modifyParams) {
+    private void 노선_수정_완료(ExtractableResponse<Response> response, Map<String, Object> modifyParams) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         var lineName = response.jsonPath().getString("name");
         assertThat(lineName).isEqualTo(modifyParams.get("name"));

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -185,7 +185,9 @@ class LineAcceptanceTest extends AcceptanceTest {
     private void 노선_조회_완료(ExtractableResponse<Response> response, Map<String, Object> params) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
         var lineName = response.jsonPath().getString("name");
+        var stations = response.jsonPath().getList("stations");
         assertThat(lineName).isEqualTo(params.get("name"));
+        assertThat(stations.size()).isEqualTo(2);
     }
 
     private void 노선_수정_완료(ExtractableResponse<Response> response, Map<String, Object> modifyParams) {

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -20,18 +20,16 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine() {
         // given
-        var station1 = StationFixture.신논현역;
-        var station2 = StationFixture.강남역;
-        역_생성_요청(station1);
-        역_생성_요청(station2);
+        역_생성_요청(StationFixture.신논현역);
+        역_생성_요청(StationFixture.강남역);
 
-        var params = LineFixture.신분당선;
+        var 노선1 = LineFixture.신분당선;
 
         // when
-        var response = 노선_생성_요청(params);
+        var 노선_생성_응답 = 노선_생성_요청(노선1);
 
         // then
-        노선_생성_완료(response);
+        노선_생성_완료(노선_생성_응답);
     }
 
     /**
@@ -44,24 +42,21 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        var station1 = StationFixture.신논현역;
-        var station2 = StationFixture.강남역;
-        var station3 = StationFixture.역삼역;
-        역_생성_요청(station1);
-        역_생성_요청(station2);
-        역_생성_요청(station3);
+        역_생성_요청(StationFixture.신논현역);
+        역_생성_요청(StationFixture.강남역);
+        역_생성_요청(StationFixture.역삼역);
 
-        var params1 = LineFixture.신분당선;
-        노선_생성_요청(params1);
+        var 노선1 = LineFixture.신분당선;
+        노선_생성_요청(노선1);
 
-        var params2 = LineFixture.이호선;
-        노선_생성_요청(params2);
+        var 노선2 = LineFixture.이호선;
+        노선_생성_요청(노선2);
 
         // when
-        var response = LineStep.노선_목록_조회_요청();
+        var 노선_목록_조회_응답 = LineStep.노선_목록_조회_요청();
 
         // then
-        노선_목록_조회_완료(response, params1, params2);
+        노선_목록_조회_완료(노선_목록_조회_응답, 노선1, 노선2);
     }
 
     /**
@@ -73,20 +68,18 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
-        var station1 = StationFixture.신논현역;
-        var station2 = StationFixture.강남역;
-        역_생성_요청(station1);
-        역_생성_요청(station2);
+        역_생성_요청(StationFixture.신논현역);
+        역_생성_요청(StationFixture.강남역);
 
-        var params = LineFixture.신분당선;
-        var createResponse = 노선_생성_요청(params);
+        var 노선1 = LineFixture.신분당선;
+        var 노선_생성_응답 = 노선_생성_요청(노선1);
 
         // when
-        var uri = createResponse.header("Location");
-        var response = LineStep.노선_조회_요청(uri);
+        var uri = 노선_생성_응답.header("Location");
+        var 노선_조회_응답 = LineStep.노선_조회_요청(uri);
 
         // then
-        노선_조회_완료(response, params);
+        노선_조회_완료(노선_조회_응답, 노선1);
     }
 
     /**
@@ -98,22 +91,20 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine() {
         // given
-        var station1 = StationFixture.신논현역;
-        var station2 = StationFixture.강남역;
-        역_생성_요청(station1);
-        역_생성_요청(station2);
+        역_생성_요청(StationFixture.신논현역);
+        역_생성_요청(StationFixture.강남역);
 
-        var params = LineFixture.신분당선;
-        var createResponse = 노선_생성_요청(params);
+        var 노선1 = LineFixture.신분당선;
+        var 노선_생성_응답 = 노선_생성_요청(노선1);
 
         // when
-        var modifyParams = LineFixture.이호선;
+        var 노선2 = LineFixture.이호선;
 
-        var uri = createResponse.header("Location");
-        var response = LineStep.노선_수정_요청(uri, modifyParams);
+        var uri = 노선_생성_응답.header("Location");
+        var 노선_수정_응답 = LineStep.노선_수정_요청(uri, 노선2);
 
         // then
-        노선_수정_완료(response, modifyParams);
+        노선_수정_완료(노선_수정_응답, 노선2);
     }
 
     /**
@@ -125,20 +116,18 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        var station1 = StationFixture.신논현역;
-        var station2 = StationFixture.강남역;
-        역_생성_요청(station1);
-        역_생성_요청(station2);
+        역_생성_요청(StationFixture.신논현역);
+        역_생성_요청(StationFixture.강남역);
 
-        var params = LineFixture.신분당선;
-        var createResponse = 노선_생성_요청(params);
+        var 노선1 = LineFixture.신분당선;
+        var 노선_생성_응답 = 노선_생성_요청(노선1);
 
         // when
-        var uri = createResponse.header("Location");
-        var response = 노선_삭제_요청(uri);
+        var uri = 노선_생성_응답.header("Location");
+        var 노선_삭제_응답 = 노선_삭제_요청(uri);
 
         // then
-        노선_삭제_완료(response);
+        노선_삭제_완료(노선_삭제_응답);
     }
 
     /**
@@ -150,19 +139,17 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLineWithDuplicateName() {
         // given
-        var station1 = StationFixture.신논현역;
-        var station2 = StationFixture.강남역;
-        역_생성_요청(station1);
-        역_생성_요청(station2);
+        역_생성_요청(StationFixture.신논현역);
+        역_생성_요청(StationFixture.강남역);
 
-        var params = LineFixture.신분당선;
-        노선_생성_요청(params);
+        var 노선1 = LineFixture.신분당선;
+        노선_생성_요청(노선1);
 
         // when
-        var response = 노선_생성_요청(params);
+        var 노선_생성_응답 = 노선_생성_요청(노선1);
 
         // then
-        중복된_노선_생성_예외(response);
+        중복된_노선_생성_예외(노선_생성_응답);
     }
 
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,19 +1,13 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import nextstep.subway.acceptance.step.StationStep;
-import nextstep.subway.fixture.LineFixture;
 import nextstep.subway.acceptance.step.LineStep;
+import nextstep.subway.fixture.LineFixture;
 import nextstep.subway.fixture.StationFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
-import java.util.Arrays;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.acceptance.step.LineStep.*;
+import static nextstep.subway.acceptance.step.StationStep.역_생성_요청;
 
 @DisplayName("지하철 노선 관리 기능")
 class LineAcceptanceTest extends AcceptanceTest {
@@ -28,13 +22,13 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         var station1 = StationFixture.신논현역;
         var station2 = StationFixture.강남역;
-        StationStep.역_생성_요청(station1);
-        StationStep.역_생성_요청(station2);
+        역_생성_요청(station1);
+        역_생성_요청(station2);
 
         var params = LineFixture.신분당선;
 
         // when
-        var response = LineStep.노선_생성_요청(params);
+        var response = 노선_생성_요청(params);
 
         // then
         노선_생성_완료(response);
@@ -53,15 +47,15 @@ class LineAcceptanceTest extends AcceptanceTest {
         var station1 = StationFixture.신논현역;
         var station2 = StationFixture.강남역;
         var station3 = StationFixture.역삼역;
-        StationStep.역_생성_요청(station1);
-        StationStep.역_생성_요청(station2);
-        StationStep.역_생성_요청(station3);
+        역_생성_요청(station1);
+        역_생성_요청(station2);
+        역_생성_요청(station3);
 
         var params1 = LineFixture.신분당선;
-        LineStep.노선_생성_요청(params1);
+        노선_생성_요청(params1);
 
         var params2 = LineFixture.이호선;
-        LineStep.노선_생성_요청(params2);
+        노선_생성_요청(params2);
 
         // when
         var response = LineStep.노선_목록_조회_요청();
@@ -81,11 +75,11 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         var station1 = StationFixture.신논현역;
         var station2 = StationFixture.강남역;
-        StationStep.역_생성_요청(station1);
-        StationStep.역_생성_요청(station2);
+        역_생성_요청(station1);
+        역_생성_요청(station2);
 
         var params = LineFixture.신분당선;
-        var createResponse = LineStep.노선_생성_요청(params);
+        var createResponse = 노선_생성_요청(params);
 
         // when
         var uri = createResponse.header("Location");
@@ -106,11 +100,11 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         var station1 = StationFixture.신논현역;
         var station2 = StationFixture.강남역;
-        StationStep.역_생성_요청(station1);
-        StationStep.역_생성_요청(station2);
+        역_생성_요청(station1);
+        역_생성_요청(station2);
 
         var params = LineFixture.신분당선;
-        var createResponse = LineStep.노선_생성_요청(params);
+        var createResponse = 노선_생성_요청(params);
 
         // when
         var modifyParams = LineFixture.이호선;
@@ -133,18 +127,18 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         var station1 = StationFixture.신논현역;
         var station2 = StationFixture.강남역;
-        StationStep.역_생성_요청(station1);
-        StationStep.역_생성_요청(station2);
+        역_생성_요청(station1);
+        역_생성_요청(station2);
 
         var params = LineFixture.신분당선;
-        var createResponse = LineStep.노선_생성_요청(params);
+        var createResponse = 노선_생성_요청(params);
 
         // when
         var uri = createResponse.header("Location");
-        var response = LineStep.노선_삭제_요청(uri);
+        var response = 노선_삭제_요청(uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        노선_삭제_완료(response);
     }
 
     /**
@@ -158,41 +152,17 @@ class LineAcceptanceTest extends AcceptanceTest {
         // given
         var station1 = StationFixture.신논현역;
         var station2 = StationFixture.강남역;
-        StationStep.역_생성_요청(station1);
-        StationStep.역_생성_요청(station2);
+        역_생성_요청(station1);
+        역_생성_요청(station2);
 
         var params = LineFixture.신분당선;
-        var createResponse = LineStep.노선_생성_요청(params);
+        노선_생성_요청(params);
 
         // when
-        var response = LineStep.노선_생성_요청(params);
+        var response = 노선_생성_요청(params);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+        중복된_노선_생성_예외(response);
     }
 
-    private void 노선_생성_완료(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
-    }
-
-    private void 노선_목록_조회_완료(ExtractableResponse<Response> response, Map<String, Object>... paramsArgs) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        var lineNames = response.jsonPath().getList("name");
-        assertThat(lineNames).contains(Arrays.stream(paramsArgs).map(m -> m.get("name")).toArray());
-    }
-
-    private void 노선_조회_완료(ExtractableResponse<Response> response, Map<String, Object> params) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        var lineName = response.jsonPath().getString("name");
-        var stations = response.jsonPath().getList("stations");
-        assertThat(lineName).isEqualTo(params.get("name"));
-        assertThat(stations.size()).isEqualTo(2);
-    }
-
-    private void 노선_수정_완료(ExtractableResponse<Response> response, Map<String, Object> modifyParams) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        var lineName = response.jsonPath().getString("name");
-        assertThat(lineName).isEqualTo(modifyParams.get("name"));
-    }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,0 +1,49 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.acceptance.step.LineStep;
+import nextstep.subway.acceptance.step.SectionStep;
+import nextstep.subway.acceptance.step.StationStep;
+import nextstep.subway.fixture.LineFixture;
+import nextstep.subway.fixture.SectionFixture;
+import nextstep.subway.fixture.StationFixture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("지하철 구간 관리 기능")
+class SectionAcceptanceTest extends AcceptanceTest {
+
+    @DisplayName("지하철 노선에 구간 등록")
+    @Test
+    void createSection() {
+        // given
+        var stationParams = StationFixture.역삼역;
+        StationStep.역_생성_요청(stationParams);
+
+        var lineCreateResponse = 신분당선_생성_완료();
+        var params = SectionFixture.of(2L, 3L, 10);
+
+        // when
+        var lineUri = lineCreateResponse.header("Location");
+        var response = SectionStep.구간_생성_요청(lineUri, params);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+
+    private ExtractableResponse<Response> 신분당선_생성_완료() {
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        StationStep.역_생성_요청(station1);
+        StationStep.역_생성_요청(station2);
+
+        var params = LineFixture.신분당선;
+        return LineStep.노선_생성_요청(params);
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -35,6 +35,26 @@ class SectionAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
+    @DisplayName("지하철 노선에 구간 삭제")
+    @Test
+    void deleteSection() {
+        // given
+        var stationParams = StationFixture.역삼역;
+        StationStep.역_생성_요청(stationParams);
+
+        var lineCreateResponse = 신분당선_생성_완료();
+        var params = SectionFixture.of(2L, 3L, 10);
+
+        var lineUri = lineCreateResponse.header("Location");
+        SectionStep.구간_생성_요청(lineUri, params);
+
+        // when
+        var response = SectionStep.구간_삭제_요청(lineUri, 3L);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
 
     private ExtractableResponse<Response> 신분당선_생성_완료() {
         var station1 = StationFixture.신논현역;

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,18 +1,13 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import nextstep.subway.acceptance.step.LineStep;
-import nextstep.subway.acceptance.step.SectionStep;
-import nextstep.subway.acceptance.step.StationStep;
-import nextstep.subway.fixture.LineFixture;
 import nextstep.subway.fixture.SectionFixture;
 import nextstep.subway.fixture.StationFixture;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.acceptance.step.LineStep.신분당선_생성_완료;
+import static nextstep.subway.acceptance.step.SectionStep.*;
+import static nextstep.subway.acceptance.step.StationStep.역_생성_요청;
 
 @DisplayName("지하철 구간 관리 기능")
 class SectionAcceptanceTest extends AcceptanceTest {
@@ -22,17 +17,17 @@ class SectionAcceptanceTest extends AcceptanceTest {
     void createSection() {
         // given
         var stationParams = StationFixture.역삼역;
-        StationStep.역_생성_요청(stationParams);
+        역_생성_요청(stationParams);
 
         var lineCreateResponse = 신분당선_생성_완료();
-        var params = SectionFixture.of(2L, 3L, 10);
 
         // when
         var lineUri = lineCreateResponse.header("Location");
-        var response = SectionStep.구간_생성_요청(lineUri, params);
+        var params = SectionFixture.of(2L, 3L, 10);
+        var response = 구간_등록_요청(lineUri, params);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        구간_등록_성공(response);
     }
 
     @DisplayName("지하철 노선에 구간 삭제")
@@ -40,30 +35,18 @@ class SectionAcceptanceTest extends AcceptanceTest {
     void deleteSection() {
         // given
         var stationParams = StationFixture.역삼역;
-        StationStep.역_생성_요청(stationParams);
+        역_생성_요청(stationParams);
 
         var lineCreateResponse = 신분당선_생성_완료();
         var params = SectionFixture.of(2L, 3L, 10);
 
         var lineUri = lineCreateResponse.header("Location");
-        SectionStep.구간_생성_요청(lineUri, params);
+        구간_등록_요청(lineUri, params);
 
         // when
-        var response = SectionStep.구간_삭제_요청(lineUri, 3L);
+        var response = 구간_삭제_요청(lineUri, 3L);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        구간_삭제_성공(response);
     }
-
-
-    private ExtractableResponse<Response> 신분당선_생성_완료() {
-        var station1 = StationFixture.신논현역;
-        var station2 = StationFixture.강남역;
-        StationStep.역_생성_요청(station1);
-        StationStep.역_생성_요청(station2);
-
-        var params = LineFixture.신분당선;
-        return LineStep.노선_생성_요청(params);
-    }
-
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -16,37 +16,35 @@ class SectionAcceptanceTest extends AcceptanceTest {
     @Test
     void createSection() {
         // given
-        var stationParams = StationFixture.역삼역;
-        역_생성_요청(stationParams);
+        역_생성_요청(StationFixture.역삼역);
 
-        var lineCreateResponse = 신분당선_생성_완료();
+        var 노선_생성_응답 = 신분당선_생성_완료();
 
         // when
-        var lineUri = lineCreateResponse.header("Location");
-        var params = SectionFixture.of(2L, 3L, 10);
-        var response = 구간_등록_요청(lineUri, params);
+        var lineUri = 노선_생성_응답.header("Location");
+        var 구간1 = SectionFixture.of(2L, 3L, 10);
+        var 구간_등록_응답 = 구간_등록_요청(lineUri, 구간1);
 
         // then
-        구간_등록_성공(response);
+        구간_등록_성공(구간_등록_응답);
     }
 
     @DisplayName("지하철 노선에 구간 삭제")
     @Test
     void deleteSection() {
         // given
-        var stationParams = StationFixture.역삼역;
-        역_생성_요청(stationParams);
+        역_생성_요청(StationFixture.역삼역);
 
-        var lineCreateResponse = 신분당선_생성_완료();
-        var params = SectionFixture.of(2L, 3L, 10);
+        var 노선_생성_응답 = 신분당선_생성_완료();
+        var 구간1 = SectionFixture.of(2L, 3L, 10);
 
-        var lineUri = lineCreateResponse.header("Location");
-        구간_등록_요청(lineUri, params);
+        var lineUri = 노선_생성_응답.header("Location");
+        구간_등록_요청(lineUri, 구간1);
 
         // when
-        var response = 구간_삭제_요청(lineUri, 3L);
+        var 구간_삭제_응답 = 구간_삭제_요청(lineUri, 3L);
 
         // then
-        구간_삭제_성공(response);
+        구간_삭제_성공(구간_삭제_응답);
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -17,13 +17,13 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void createStation() {
         // given
-        var params = StationFixture.강남역;
+        var 역1 = StationFixture.강남역;
 
         // when
-        var response = 역_생성_요청(params);
+        var 역_생성_응답 = 역_생성_요청(역1);
 
         // then
-        역_생성_완료(response);
+        역_생성_완료(역_생성_응답);
     }
 
     /**
@@ -36,16 +36,16 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void getStations() {
         /// given
-        var params1 = StationFixture.강남역;
-        역_생성_요청(params1);
+        var 역1 = StationFixture.강남역;
+        역_생성_요청(역1);
 
-        var params2 = StationFixture.역삼역;
-        역_생성_요청(params2);
+        var 역2 = StationFixture.역삼역;
+        역_생성_요청(역2);
 
         // when
-        var response = 역_목록_조회_요청();
+        var 역_목록_조회_응답 = 역_목록_조회_요청();
 
-        역_목록_조회_완료(response, params1, params2);
+        역_목록_조회_완료(역_목록_조회_응답, 역1, 역2);
     }
 
     /**
@@ -57,15 +57,14 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        var params = StationFixture.강남역;
-        var createResponse = 역_생성_요청(params);
+        var 역_생성_응답 = 역_생성_요청(StationFixture.강남역);
 
         // when
-        String uri = createResponse.header("Location");
-        var response = 역_삭제_요청(uri);
+        String uri = 역_생성_응답.header("Location");
+        var 역_삭제_응답 = 역_삭제_요청(uri);
 
         // then
-        역_삭제_완료(response);
+        역_삭제_완료(역_삭제_응답);
     }
 
     /**
@@ -77,14 +76,14 @@ class StationAcceptanceTest extends AcceptanceTest {
     @Test
     void createStationWithDuplicateName() {
         // given
-        var params = StationFixture.강남역;
-        역_생성_요청(params);
+        var 역1 = StationFixture.강남역;
+        역_생성_요청(역1);
 
         // when
-        var response = 역_생성_요청(params);
+        var 역_생성_응답 = 역_생성_요청(역1);
 
         // then
-        중복된_역_생성_예외(response);
+        중복된_역_생성_예외(역_생성_응답);
     }
 
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -1,18 +1,10 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
 import nextstep.subway.fixture.StationFixture;
-import nextstep.subway.acceptance.step.StationStep;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.acceptance.step.StationStep.*;
 
 @DisplayName("지하철역 관리 기능")
 class StationAcceptanceTest extends AcceptanceTest {
@@ -28,7 +20,7 @@ class StationAcceptanceTest extends AcceptanceTest {
         var params = StationFixture.강남역;
 
         // when
-        var response = StationStep.역_생성_요청(params);
+        var response = 역_생성_요청(params);
 
         // then
         역_생성_완료(response);
@@ -45,13 +37,13 @@ class StationAcceptanceTest extends AcceptanceTest {
     void getStations() {
         /// given
         var params1 = StationFixture.강남역;
-        var createResponse1 = StationStep.역_생성_요청(params1);
+        역_생성_요청(params1);
 
         var params2 = StationFixture.역삼역;
-        var createResponse2 = StationStep.역_생성_요청(params2);
+        역_생성_요청(params2);
 
         // when
-        var response = StationStep.역_목록_조회_요청();
+        var response = 역_목록_조회_요청();
 
         역_목록_조회_완료(response, params1, params2);
     }
@@ -66,14 +58,14 @@ class StationAcceptanceTest extends AcceptanceTest {
     void deleteStation() {
         // given
         var params = StationFixture.강남역;
-        var createResponse = StationStep.역_생성_요청(params);
+        var createResponse = 역_생성_요청(params);
 
         // when
         String uri = createResponse.header("Location");
-        var response = StationStep.역_삭제_요청(uri);
+        var response = 역_삭제_요청(uri);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        역_삭제_완료(response);
     }
 
     /**
@@ -86,23 +78,13 @@ class StationAcceptanceTest extends AcceptanceTest {
     void createStationWithDuplicateName() {
         // given
         var params = StationFixture.강남역;
-        var createResponse = StationStep.역_생성_요청(params);
+        역_생성_요청(params);
 
         // when
-        var response = StationStep.역_생성_요청(params);
+        var response = 역_생성_요청(params);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+        중복된_역_생성_예외(response);
     }
 
-    private void 역_생성_완료(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        assertThat(response.header("Location")).isNotBlank();
-    }
-
-    private void 역_목록_조회_완료(ExtractableResponse<Response> response, Map<String, String>... paramsArgs) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        List<String> stationNames = response.jsonPath().getList("name");
-        assertThat(stationNames).contains(Arrays.stream(paramsArgs).map(m -> m.get("name")).toArray(String[]::new));
-    }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineStep.java
@@ -11,7 +11,7 @@ public class LineStep {
 
     private static final String PATH = "/lines";
 
-    public static ExtractableResponse<Response> 노선_생성_요청(Map<String, String> params) {
+    public static ExtractableResponse<Response> 노선_생성_요청(Map<String, Object> params) {
         return RestAssured.given().log().all()
                 .body(params)
                 .contentType(ContentType.JSON)
@@ -39,7 +39,7 @@ public class LineStep {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 노선_수정_요청(String uri, Map<String, String> params) {
+    public static ExtractableResponse<Response> 노선_수정_요청(String uri, Map<String, Object> params) {
         return RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)

--- a/src/test/java/nextstep/subway/acceptance/step/LineStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineStep.java
@@ -4,8 +4,15 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.fixture.LineFixture;
+import nextstep.subway.fixture.StationFixture;
+import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
 import java.util.Map;
+
+import static nextstep.subway.acceptance.step.StationStep.역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class LineStep {
 
@@ -55,6 +62,50 @@ public class LineStep {
                 .delete(uri)
                 .then().log().all()
                 .extract();
+    }
+
+    public static ExtractableResponse<Response> 신분당선_생성_완료() {
+        var station1 = StationFixture.신논현역;
+        var station2 = StationFixture.강남역;
+        역_생성_요청(station1);
+        역_생성_요청(station2);
+
+        var params = LineFixture.신분당선;
+        return LineStep.노선_생성_요청(params);
+    }
+
+
+    public static void 노선_생성_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
+    }
+
+    public static void 노선_목록_조회_완료(ExtractableResponse<Response> response, Map<String, Object>... paramsArgs) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        var lineNames = response.jsonPath().getList("name");
+        assertThat(lineNames).contains(Arrays.stream(paramsArgs).map(m -> m.get("name")).toArray());
+    }
+
+    public static void 노선_조회_완료(ExtractableResponse<Response> response, Map<String, Object> params) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        var lineName = response.jsonPath().getString("name");
+        var stations = response.jsonPath().getList("stations");
+        assertThat(lineName).isEqualTo(params.get("name"));
+        assertThat(stations.size()).isEqualTo(2);
+    }
+
+    public static void 노선_수정_완료(ExtractableResponse<Response> response, Map<String, Object> modifyParams) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        var lineName = response.jsonPath().getString("name");
+        assertThat(lineName).isEqualTo(modifyParams.get("name"));
+    }
+
+    public static void 노선_삭제_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static void 중복된_노선_생성_예외(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 
 }

--- a/src/test/java/nextstep/subway/acceptance/step/LineStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/LineStep.java
@@ -1,4 +1,4 @@
-package nextstep.subway.acceptance.rest;
+package nextstep.subway.acceptance.step;
 
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -7,22 +7,21 @@ import io.restassured.response.Response;
 
 import java.util.Map;
 
-public class BaseCrudStep {
+public class LineStep {
 
-    public static ExtractableResponse<Response> createResponse(
-            String uri,
-            Map<String, String> params
-    ) {
+    private static final String PATH = "/lines";
+
+    public static ExtractableResponse<Response> 노선_생성_요청(Map<String, String> params) {
         return RestAssured.given().log().all()
                 .body(params)
                 .contentType(ContentType.JSON)
                 .when()
-                .post(uri)
+                .post(PATH)
                 .then().log().all()
                 .extract();
     }
 
-    public static ExtractableResponse<Response> readResponse(String uri) {
+    public static ExtractableResponse<Response> 노선_조회_요청(String uri) {
         return RestAssured.given().log().all()
                 .accept(ContentType.JSON)
                 .when()
@@ -31,10 +30,16 @@ public class BaseCrudStep {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> updateResponse(
-            String uri,
-            Map<String, String> params
-    ) {
+    public static ExtractableResponse<Response> 노선_목록_조회_요청() {
+        return RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .when()
+                .get(PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 노선_수정_요청(String uri, Map<String, String> params) {
         return RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)
@@ -44,11 +49,12 @@ public class BaseCrudStep {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> deleteResponse(String uri) {
+    public static ExtractableResponse<Response> 노선_삭제_요청(String uri) {
         return RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .delete(uri)
                 .then().log().all()
                 .extract();
     }
+
 }

--- a/src/test/java/nextstep/subway/acceptance/step/SectionStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/SectionStep.java
@@ -4,14 +4,17 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
 
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SectionStep {
 
     private static final String PATH = "/sections";
 
-    public static ExtractableResponse<Response> 구간_생성_요청(String lineUri, Map<String, Object> params) {
+    public static ExtractableResponse<Response> 구간_등록_요청(String lineUri, Map<String, Object> params) {
         return RestAssured.given().log().all()
                 .body(params)
                 .contentType(ContentType.JSON)
@@ -28,5 +31,13 @@ public class SectionStep {
                 .delete(lineUri + PATH + "?stationId=" + stationId)
                 .then().log().all()
                 .extract();
+    }
+
+    public static void 구간_등록_성공(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 구간_삭제_성공(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/SectionStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/SectionStep.java
@@ -1,0 +1,25 @@
+package nextstep.subway.acceptance.step;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+public class SectionStep {
+
+    private static final String PATH = "/sections";
+
+    public static ExtractableResponse<Response> 구간_생성_요청(String lineUri, Map<String, Object> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post(lineUri + PATH)
+                .then().log().all()
+                .extract();
+    }
+
+
+}

--- a/src/test/java/nextstep/subway/acceptance/step/SectionStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/SectionStep.java
@@ -21,5 +21,12 @@ public class SectionStep {
                 .extract();
     }
 
-
+    public static ExtractableResponse<Response> 구간_삭제_요청(String lineUri, Long stationId) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .when()
+                .delete(lineUri + PATH + "?stationId=" + stationId)
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/step/StationStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationStep.java
@@ -1,0 +1,40 @@
+package nextstep.subway.acceptance.step;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+
+import java.util.Map;
+
+public class StationStep {
+
+    private static final String PATH = "/stations";
+
+    public static ExtractableResponse<Response> 역_생성_요청(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(ContentType.JSON)
+                .when()
+                .post(PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 역_목록_조회_요청() {
+        return RestAssured.given().log().all()
+                .accept(ContentType.JSON)
+                .when()
+                .get(PATH)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 역_삭제_요청(String uri) {
+        return RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .delete(uri)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/step/StationStep.java
+++ b/src/test/java/nextstep/subway/acceptance/step/StationStep.java
@@ -4,8 +4,13 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class StationStep {
 
@@ -36,5 +41,24 @@ public class StationStep {
                 .delete(uri)
                 .then().log().all()
                 .extract();
+    }
+
+    public static void 역_생성_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.header("Location")).isNotBlank();
+    }
+
+    public static void 역_목록_조회_완료(ExtractableResponse<Response> response, Map<String, String>... paramsArgs) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        List<String> stationNames = response.jsonPath().getList("name");
+        assertThat(stationNames).contains(Arrays.stream(paramsArgs).map(m -> m.get("name")).toArray(String[]::new));
+    }
+
+    public static void 역_삭제_완료(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static void 중복된_역_생성_예외(ExtractableResponse<Response> response){
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 }

--- a/src/test/java/nextstep/subway/fixture/LineFixture.java
+++ b/src/test/java/nextstep/subway/fixture/LineFixture.java
@@ -1,0 +1,15 @@
+package nextstep.subway.fixture;
+
+import java.util.Map;
+
+public class LineFixture {
+
+    public static final Map<String, String> 신분당선 = Map.of(
+            "name", "신분당선",
+            "color", "bg-red-600"
+    );
+    public static final Map<String, String> 구분당선 = Map.of(
+            "name", "구분당선",
+            "color", "bg-blue-600"
+    );
+}

--- a/src/test/java/nextstep/subway/fixture/LineFixture.java
+++ b/src/test/java/nextstep/subway/fixture/LineFixture.java
@@ -4,12 +4,18 @@ import java.util.Map;
 
 public class LineFixture {
 
-    public static final Map<String, String> 신분당선 = Map.of(
+    public static final Map<String, Object> 신분당선 = Map.of(
             "name", "신분당선",
-            "color", "bg-red-600"
+            "color", "bg-red-600",
+            "upStationId", 1L,
+            "downStationId", 2L,
+            "distance", 10
     );
-    public static final Map<String, String> 구분당선 = Map.of(
-            "name", "구분당선",
-            "color", "bg-blue-600"
+    public static final Map<String, Object> 이호선 = Map.of(
+            "name", "이호선",
+            "color", "bg-green-600",
+            "upStationId", 2L,
+            "downStationId", 3L,
+            "distance", 10
     );
 }

--- a/src/test/java/nextstep/subway/fixture/SectionFixture.java
+++ b/src/test/java/nextstep/subway/fixture/SectionFixture.java
@@ -1,0 +1,15 @@
+package nextstep.subway.fixture;
+
+import java.util.Map;
+
+public class SectionFixture {
+
+    public static Map<String, Object> of(Long upStationId, Long downStationId, int distance) {
+        return Map.of(
+                "downStationId", downStationId,
+                "upStationId", upStationId,
+                "distance", distance
+        );
+    }
+
+}

--- a/src/test/java/nextstep/subway/fixture/StationFixture.java
+++ b/src/test/java/nextstep/subway/fixture/StationFixture.java
@@ -1,0 +1,14 @@
+package nextstep.subway.fixture;
+
+import java.util.Map;
+
+public class StationFixture {
+
+    public static final Map<String, String> 강남역 = Map.of(
+            "name", "강남역"
+    );
+    public static final Map<String, String> 역삼역 = Map.of(
+            "name", "역삼역"
+    );
+
+}

--- a/src/test/java/nextstep/subway/fixture/StationFixture.java
+++ b/src/test/java/nextstep/subway/fixture/StationFixture.java
@@ -4,11 +4,26 @@ import java.util.Map;
 
 public class StationFixture {
 
+    public static final Map<String, String> 신논현역 = Map.of(
+            "name", "신논현역"
+    );
     public static final Map<String, String> 강남역 = Map.of(
             "name", "강남역"
     );
     public static final Map<String, String> 역삼역 = Map.of(
             "name", "역삼역"
+    );
+    public static final Map<String, String> 서초역 = Map.of(
+            "name", "서초역"
+    );
+    public static final Map<String, String> 방배역 = Map.of(
+            "name", "방배역"
+    );
+    public static final Map<String, String> 사당역 = Map.of(
+            "name", "사당역"
+    );
+    public static final Map<String, String> 선릉역 = Map.of(
+            "name", "선릉역"
     );
 
 }


### PR DESCRIPTION
안녕하세요~
JPA 경험이 부족한 거 같아 따로 추가적으로 학습하면서  조금 늦었습니다😭

지난번 풀리퀘스트에서 [등록된 구간을 통해 역 목록 조회 기능](https://github.com/next-step/atdd-subway-map/pull/227) 리뷰해주신 부분을 반영하여 3단계미션을 진행하기 전에 처음 커밋에서 리팩토링을 진행해보았습니다.

https://github.com/next-step/atdd-subway-map/pull/227#discussion_r790354426
여기서 말씀주신 then도 하나의 step으로 볼수 있지 않을까라고 해주셨는데
then은 약간 검증의 느낌이라 생각해서 Test클래스 내에 존재해야 하지 않을까 싶어서 검증이 여러개면(여러줄이면) 따로 메서드로 분리하는 식으로 해보았습니다.

그리고는 나름대로 3단계 미션을 구현해보았는데 중복 테스트코드를 줄인다고 줄였는데도 더 줄일 수 있지 않나 생각이 들기도 하네요.
main코드에서는 노선을 생성하면서 구간도 같이 생성하다 보니 jpa 양방향 관계에 대해 조금 고민해서 생성했는데 잘 짜여졌는지 궁금하기도 합니다.

리뷰 잘 부탁드립니다🙏
