### PR TITLE
🚀 3단계 - 지하철 구간 관리

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -3,8 +3,7 @@ package nextstep.subway.applicaion;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.exception.LineDuplicateException;
-import nextstep.subway.domain.Line;
-import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,20 +14,34 @@ import java.util.stream.Collectors;
 @Transactional
 public class LineService {
     private final LineRepository lineRepository;
+    private final SectionRepository sectionRepository;
+    private final StationRepository stationRepository;
 
-    public LineService(LineRepository lineRepository) {
+    public LineService(LineRepository lineRepository, SectionRepository sectionRepository, StationRepository stationRepository) {
         this.lineRepository = lineRepository;
+        this.sectionRepository = sectionRepository;
+        this.stationRepository = stationRepository;
     }
 
     public LineResponse saveLine(LineRequest request) {
 
         String name = request.getName();
 
-        if (lineRepository.findByName(name).isPresent()) {
+        if (lineRepository.findByName(name)
+                          .isPresent()) {
             throw new LineDuplicateException();
         }
 
         Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
+        Station upStation = stationRepository.findById(request.getUpStationId())
+                                             .orElseThrow(() -> new RuntimeException("존재하지 않는 상행역 입니다."));
+        Station downStation = stationRepository.findById(request.getDownStationId())
+                                               .orElseThrow(() -> new RuntimeException("존재하지 않는 하행역 입니다."));
+        Section section = new Section(line, upStation, downStation);
+
+        line.addSection(section);
+        sectionRepository.save(section);
+
         return new LineResponse(line);
     }
 
@@ -37,8 +50,8 @@ public class LineService {
         List<Line> lines = lineRepository.findAll();
 
         return lines.stream()
-                .map(this::createLineResponse)
-                .collect(Collectors.toList());
+                    .map(this::createLineResponse)
+                    .collect(Collectors.toList());
     }
 
     private LineResponse createLineResponse(Line line) {
@@ -47,12 +60,14 @@ public class LineService {
 
     public LineResponse findLineBy(Long id) {
         //TODO: Exception 처리
-        Line findLine = lineRepository.findById(id).orElseThrow(RuntimeException::new);
+        Line findLine = lineRepository.findById(id)
+                                      .orElseThrow(() -> new RuntimeException("해당하는 노선을 찾을 수 없습니다."));
         return createLineResponse(findLine);
     }
 
     public void modifyBy(Long id, LineRequest lineRequest) {
-        Line findLine = lineRepository.findById(id).orElseThrow(RuntimeException::new);
+        Line findLine = lineRepository.findById(id)
+                                      .orElseThrow(RuntimeException::new);
         findLine.change(lineRequest.getName(), lineRequest.getColor());
     }
 

--- a/src/main/java/nextstep/subway/applicaion/SectionService.java
+++ b/src/main/java/nextstep/subway/applicaion/SectionService.java
@@ -3,6 +3,7 @@ package nextstep.subway.applicaion;
 import nextstep.subway.applicaion.dto.SectionRequest;
 import nextstep.subway.applicaion.exception.NewDownStationDuplicateException;
 import nextstep.subway.applicaion.exception.NotRegisterDownStationException;
+import nextstep.subway.applicaion.exception.NotRemoveStationException;
 import nextstep.subway.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,7 +58,32 @@ public class SectionService {
     }
 
     @Transactional
-    public void delete(Long lineId, Long downStationId) {
-        sectionRepository.deleteByLineIdAndDownStationId(lineId, downStationId);
+    public void delete(Long lineId, Long deleteStationId) {
+        Line findLine = lineRepository.findById(lineId)
+                                      .orElseThrow(() -> new RuntimeException("해당하는 노선을 찾을 수 없습니다."));
+
+
+        boolean isExistStation = false;
+        for (Section section : findLine.getSectionList()) {
+            Long findDownStationId = section.getDownStation()
+                                            .getId();
+            Long findUpStationId = section.getUpStation()
+                                          .getId();
+
+            if (deleteStationId.equals(findUpStationId)) {
+                throw new NotRemoveStationException();
+            }
+
+            if (deleteStationId.equals(findDownStationId)) {
+                isExistStation = true;
+            }
+        }
+
+        if (!isExistStation) {
+            throw new NotRemoveStationException();
+        }
+
+
+        sectionRepository.deleteByLineIdAndDownStationId(lineId, deleteStationId);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/SectionService.java
+++ b/src/main/java/nextstep/subway/applicaion/SectionService.java
@@ -5,6 +5,7 @@ import nextstep.subway.applicaion.exception.NewDownStationDuplicateException;
 import nextstep.subway.applicaion.exception.NotRegisterDownStationException;
 import nextstep.subway.domain.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class SectionService {
@@ -55,4 +56,8 @@ public class SectionService {
         return sectionRepository.save(saveSection);
     }
 
+    @Transactional
+    public void delete(Long lineId, Long downStationId) {
+        sectionRepository.deleteByLineIdAndDownStationId(lineId, downStationId);
+    }
 }

--- a/src/main/java/nextstep/subway/applicaion/SectionService.java
+++ b/src/main/java/nextstep/subway/applicaion/SectionService.java
@@ -1,0 +1,36 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.domain.*;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SectionService {
+    private final SectionRepository sectionRepository;
+    private final LineRepository lineRepository;
+    private final StationRepository stationRepository;
+
+    public SectionService(SectionRepository sectionRepository, LineRepository lineRepository, StationRepository stationRepository) {
+        this.sectionRepository = sectionRepository;
+        this.lineRepository = lineRepository;
+        this.stationRepository = stationRepository;
+    }
+
+    public Section saveSection(Long lineId, SectionRequest sectionRequest) {
+        Line findLine = lineRepository.findById(lineId)
+                                      .orElseThrow(() -> new RuntimeException("해당하는 노선을 찾을 수 없습니다."));
+
+        Long upStationId = Long.valueOf(sectionRequest.getUpStationId());
+        Long downStationId = Long.valueOf(sectionRequest.getDownStationId());
+
+        Station upStation = stationRepository.findById(upStationId)
+                                             .orElseThrow(() -> new RuntimeException("존재하지 않는 상행역 입니다."));
+        Station downStation = stationRepository.findById(downStationId)
+                                               .orElseThrow(() -> new RuntimeException("존재하지 않는 하행역 입니다."));
+
+        Section saveSection = new Section(findLine, upStation, downStation);
+
+        return sectionRepository.save(saveSection);
+    }
+
+}

--- a/src/main/java/nextstep/subway/applicaion/SectionService.java
+++ b/src/main/java/nextstep/subway/applicaion/SectionService.java
@@ -63,6 +63,10 @@ public class SectionService {
                                       .orElseThrow(() -> new RuntimeException("해당하는 노선을 찾을 수 없습니다."));
 
 
+        if(findLine.getSectionList().size() == 1){
+            throw new NotRemoveStationException("구간이 1개인 경우 역을 삭제할 수 없다.");
+        }
+
         boolean isExistStation = false;
         for (Section section : findLine.getSectionList()) {
             Long findDownStationId = section.getDownStation()
@@ -71,7 +75,7 @@ public class SectionService {
                                           .getId();
 
             if (deleteStationId.equals(findUpStationId)) {
-                throw new NotRemoveStationException();
+                throw new NotRemoveStationException("지하철 노선에 등록된 하행 종점역만 제거할 수 있다.");
             }
 
             if (deleteStationId.equals(findDownStationId)) {
@@ -80,7 +84,7 @@ public class SectionService {
         }
 
         if (!isExistStation) {
-            throw new NotRemoveStationException();
+            throw new NotRemoveStationException("지하철 노선에 등록된 역만 제거할 수 있다.");
         }
 
 

--- a/src/main/java/nextstep/subway/applicaion/SectionService.java
+++ b/src/main/java/nextstep/subway/applicaion/SectionService.java
@@ -1,6 +1,7 @@
 package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.exception.NotRegisterDownStationException;
 import nextstep.subway.domain.*;
 import org.springframework.stereotype.Service;
 
@@ -19,9 +20,21 @@ public class SectionService {
     public Section saveSection(Long lineId, SectionRequest sectionRequest) {
         Line findLine = lineRepository.findById(lineId)
                                       .orElseThrow(() -> new RuntimeException("해당하는 노선을 찾을 수 없습니다."));
-
         Long upStationId = Long.valueOf(sectionRequest.getUpStationId());
         Long downStationId = Long.valueOf(sectionRequest.getDownStationId());
+
+        boolean isExistDown = false;
+        for(Section section : findLine.getSectionList()){
+            if(section.getDownStation().getId().equals(upStationId)){
+                isExistDown = true;
+                break;
+            }
+        }
+
+        if(!isExistDown){
+            throw new NotRegisterDownStationException();
+        }
+
 
         Station upStation = stationRepository.findById(upStationId)
                                              .orElseThrow(() -> new RuntimeException("존재하지 않는 상행역 입니다."));

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -14,17 +14,27 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 public class StationService {
-    private StationRepository stationRepository;
+    private final StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;
+    }
+
+    public static StationResponse createStationResponse(Station station) {
+        return new StationResponse(
+                station.getId(),
+                station.getName(),
+                station.getCreatedDate(),
+                station.getModifiedDate()
+        );
     }
 
     public StationResponse saveStation(StationRequest stationRequest) {
 
         String name = stationRequest.getName();
 
-        if (stationRepository.findByName(name).isPresent()) {
+        if (stationRepository.findByName(name)
+                             .isPresent()) {
             throw new StationDuplicateException();
         }
 
@@ -32,25 +42,16 @@ public class StationService {
         return createStationResponse(station);
     }
 
+    public void deleteStationById(Long id) {
+        stationRepository.deleteById(id);
+    }
+
     @Transactional(readOnly = true)
     public List<StationResponse> findAllStations() {
         List<Station> stations = stationRepository.findAll();
 
         return stations.stream()
-                .map(this::createStationResponse)
-                .collect(Collectors.toList());
-    }
-
-    public void deleteStationById(Long id) {
-        stationRepository.deleteById(id);
-    }
-
-    private StationResponse createStationResponse(Station station) {
-        return new StationResponse(
-                station.getId(),
-                station.getName(),
-                station.getCreatedDate(),
-                station.getModifiedDate()
-        );
+                       .map(StationService::createStationResponse)
+                       .collect(Collectors.toList());
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -1,8 +1,24 @@
 package nextstep.subway.applicaion.dto;
 
 public class LineRequest {
+
     private String name;
     private String color;
+    private Long upStationId;
+    private Long downStationId;
+
+    private int distance;
+
+    public LineRequest() {
+    }
+
+    public LineRequest(String name, String color, Long upStationId, Long downStationId, int distance) {
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
 
     public String getName() {
         return name;
@@ -10,5 +26,17 @@ public class LineRequest {
 
     public String getColor() {
         return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -3,11 +3,13 @@ package nextstep.subway.applicaion.dto;
 import nextstep.subway.domain.Line;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class LineResponse {
     private final Long id;
     private final String name;
     private final String color;
+    private final List<StationResponse> stations;
     private final LocalDateTime createdDate;
     private final LocalDateTime modifiedDate;
 
@@ -15,6 +17,7 @@ public class LineResponse {
         this.id = line.getId();
         this.name = line.getName();
         this.color = line.getColor();
+        this.stations = StationResponse.toList(line.getStations());
         this.createdDate = line.getCreatedDate();
         this.modifiedDate = line.getModifiedDate();
     }
@@ -37,5 +40,9 @@ public class LineResponse {
 
     public LocalDateTime getModifiedDate() {
         return modifiedDate;
+    }
+
+    public List<StationResponse> getStations() {
+        return stations;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -1,0 +1,31 @@
+package nextstep.subway.applicaion.dto;
+
+public class SectionRequest {
+
+    private String downStationId;
+
+    private String upStationId;
+
+    private int distance;
+
+    public SectionRequest() {
+    }
+
+    public SectionRequest(String downStationId, String upStationId, int distance) {
+        this.downStationId = downStationId;
+        this.upStationId = upStationId;
+        this.distance = distance;
+    }
+
+    public String getDownStationId() {
+        return downStationId;
+    }
+
+    public String getUpStationId() {
+        return upStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
@@ -1,8 +1,0 @@
-package nextstep.subway.applicaion.dto;
-
-import java.util.ArrayList;
-import java.util.List;
-
-public class SectionResponse {
-    private final List<StationResponse> stations = new ArrayList<>();
-}

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
@@ -1,0 +1,8 @@
+package nextstep.subway.applicaion.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SectionResponse {
+    private final List<StationResponse> stations = new ArrayList<>();
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
@@ -1,12 +1,17 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.applicaion.StationService;
+import nextstep.subway.domain.Station;
+
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class StationResponse {
-    private Long id;
-    private String name;
-    private LocalDateTime createdDate;
-    private LocalDateTime modifiedDate;
+    private final Long id;
+    private final String name;
+    private final LocalDateTime createdDate;
+    private final LocalDateTime modifiedDate;
 
     public StationResponse(Long id, String name, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
@@ -25,6 +30,12 @@ public class StationResponse {
 
     public LocalDateTime getCreatedDate() {
         return createdDate;
+    }
+
+    public static List<StationResponse> toList(List<Station> stations) {
+        return stations.stream()
+                       .map(StationService::createStationResponse)
+                       .collect(Collectors.toList());
     }
 
     public LocalDateTime getModifiedDate() {

--- a/src/main/java/nextstep/subway/applicaion/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/GlobalExceptionHandler.java
@@ -24,4 +24,13 @@ public class GlobalExceptionHandler {
                 .status(e.getStatusCode())
                 .body(response);
     }
+
+    @ExceptionHandler(NotRemoveStationException.class)
+    private ResponseEntity<ErrorResponse> handleNotRemoveStationException(NotRemoveStationException e) {
+        ErrorResponse response = new ErrorResponse(e.getStatusCode(), e.getReason());
+
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(response);
+    }
 }

--- a/src/main/java/nextstep/subway/applicaion/exception/GlobalExceptionHandler.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/GlobalExceptionHandler.java
@@ -15,4 +15,13 @@ public class GlobalExceptionHandler {
                 .status(e.getStatusCode())
                 .body(response);
     }
+
+    @ExceptionHandler(NotRegisterDownStationException.class)
+    private ResponseEntity<ErrorResponse> handleNotRegisterDownStationException(NotRegisterDownStationException e) {
+        ErrorResponse response = new ErrorResponse(e.getStatusCode(), e.getReason());
+
+        return ResponseEntity
+                .status(e.getStatusCode())
+                .body(response);
+    }
 }

--- a/src/main/java/nextstep/subway/applicaion/exception/NewDownStationDuplicateException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/NewDownStationDuplicateException.java
@@ -1,0 +1,9 @@
+package nextstep.subway.applicaion.exception;
+
+public class NewDownStationDuplicateException extends ElementDuplicateException {
+    private static final String REASON = "새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.";
+
+    public NewDownStationDuplicateException() {
+        super(REASON);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exception/NotRegisterDownStationException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/NotRegisterDownStationException.java
@@ -1,0 +1,20 @@
+package nextstep.subway.applicaion.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotRegisterDownStationException extends RuntimeException{
+    private static final String REASON = "새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.";
+    private final HttpStatus statusCode = HttpStatus.BAD_REQUEST;
+
+    public NotRegisterDownStationException() {
+        super(REASON);
+    }
+
+    public HttpStatus getStatusCode() {
+        return statusCode;
+    }
+
+    public String getReason(){
+        return REASON;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exception/NotRemoveStationException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/NotRemoveStationException.java
@@ -1,0 +1,20 @@
+package nextstep.subway.applicaion.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotRemoveStationException extends RuntimeException{
+    private static final String REASON = "지하철 노선에 등록된 역(하행 종점역)만 제거할 수 있다.";
+    private final HttpStatus statusCode = HttpStatus.BAD_REQUEST;
+
+    public NotRemoveStationException() {
+        super(REASON);
+    }
+
+    public HttpStatus getStatusCode() {
+        return statusCode;
+    }
+
+    public String getReason(){
+        return REASON;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/exception/NotRemoveStationException.java
+++ b/src/main/java/nextstep/subway/applicaion/exception/NotRemoveStationException.java
@@ -10,6 +10,10 @@ public class NotRemoveStationException extends RuntimeException{
         super(REASON);
     }
 
+    public NotRemoveStationException(String message) {
+        super(message);
+    }
+
     public HttpStatus getStatusCode() {
         return statusCode;
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -58,8 +58,12 @@ public class Line extends BaseEntity {
         List<Station> stations = new ArrayList<>();
 
         for (Section s : sectionList) {
-            stations.add(s.getUpStation());
-            stations.add(s.getDownStation());
+            if(!stations.contains(s.getUpStation())) {
+                stations.add(s.getUpStation());
+            }
+            if(!stations.contains(s.getDownStation())) {
+                stations.add(s.getDownStation());
+            }
         }
 
         return stations;

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,9 +1,8 @@
 package nextstep.subway.domain;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 public class Line extends BaseEntity {
@@ -13,12 +12,21 @@ public class Line extends BaseEntity {
     private String name;
     private String color;
 
+    @OneToMany(mappedBy = "line", orphanRemoval = true)
+    private List<Section> sectionList = new ArrayList<>();
+
     public Line() {
     }
 
     public Line(String name, String color) {
         this.name = name;
         this.color = color;
+    }
+
+    public Line(String name, String color, List<Section> sectionList) {
+        this.name = name;
+        this.color = color;
+        this.sectionList = sectionList;
     }
 
     public Long getId() {
@@ -33,8 +41,27 @@ public class Line extends BaseEntity {
         return color;
     }
 
+    public List<Section> getSectionList() {
+        return sectionList;
+    }
+
     public void change(String name, String color) {
         this.name = name;
         this.color = color;
+    }
+
+    public void addSection(Section section) {
+        this.sectionList.add(section);
+    }
+
+    public List<Station> getStations() {
+        List<Station> stations = new ArrayList<>();
+
+        for (Section s : sectionList) {
+            stations.add(s.getUpStation());
+            stations.add(s.getDownStation());
+        }
+
+        return stations;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,0 +1,47 @@
+package nextstep.subway.domain;
+
+import javax.persistence.*;
+
+@Entity
+public class Section {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // Eager로 가져오는 게 맞을까?
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "LINE_ID")
+    private Line line;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "UP_STAION_ID")
+    private Station upStation;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "DOWN_STAION_ID")
+    private Station downStation;
+
+    public Section() {
+    }
+
+    public Section(Line line, Station upStation, Station downStation) {
+        this.line = line;
+        this.upStation = upStation;
+        this.downStation = downStation;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Line getLine() {
+        return line;
+    }
+
+    public Station getUpStation() {
+        return upStation;
+    }
+
+    public Station getDownStation() {
+        return downStation;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/domain/SectionRepository.java
@@ -1,0 +1,6 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SectionRepository extends JpaRepository<Section, Long> {
+}

--- a/src/main/java/nextstep/subway/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/domain/SectionRepository.java
@@ -3,4 +3,5 @@ package nextstep.subway.domain;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+    void deleteByLineIdAndDownStationId(Long lineId, Long downStationId);
 }

--- a/src/main/java/nextstep/subway/ui/SectionController.java
+++ b/src/main/java/nextstep/subway/ui/SectionController.java
@@ -2,7 +2,6 @@ package nextstep.subway.ui;
 
 import nextstep.subway.applicaion.SectionService;
 import nextstep.subway.applicaion.dto.SectionRequest;
-import nextstep.subway.applicaion.dto.SectionResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,7 +19,7 @@ public class SectionController {
     }
 
     @PostMapping
-    public ResponseEntity<SectionResponse> createSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
+    public ResponseEntity<Void> createSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
         sectionService.saveSection(lineId, sectionRequest);
         return ResponseEntity.created(URI.create("/lines/" + lineId))
                              .build();

--- a/src/main/java/nextstep/subway/ui/SectionController.java
+++ b/src/main/java/nextstep/subway/ui/SectionController.java
@@ -1,0 +1,27 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.applicaion.SectionService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.dto.SectionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/lines")
+public class SectionController {
+
+    private final SectionService sectionService;
+
+    public SectionController(SectionService sectionService) {
+        this.sectionService = sectionService;
+    }
+
+    @PostMapping("{lineId}/sections")
+    public ResponseEntity<SectionResponse> createSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
+        sectionService.saveSection(lineId, sectionRequest);
+        return ResponseEntity.created(URI.create("/lines/" + lineId))
+                             .build();
+    }
+}

--- a/src/main/java/nextstep/subway/ui/SectionController.java
+++ b/src/main/java/nextstep/subway/ui/SectionController.java
@@ -7,9 +7,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
+import java.util.Map;
 
 @RestController
-@RequestMapping("/lines")
+@RequestMapping("/lines/{lineId}/sections")
 public class SectionController {
 
     private final SectionService sectionService;
@@ -18,10 +19,18 @@ public class SectionController {
         this.sectionService = sectionService;
     }
 
-    @PostMapping("{lineId}/sections")
+    @PostMapping
     public ResponseEntity<SectionResponse> createSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
         sectionService.saveSection(lineId, sectionRequest);
         return ResponseEntity.created(URI.create("/lines/" + lineId))
+                             .build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteSection(@RequestParam final Map<String, String> queryString, @PathVariable Long lineId) {
+        Long stationId = Long.valueOf(queryString.get("stationId"));
+        sectionService.delete(lineId, stationId);
+        return ResponseEntity.noContent()
                              .build();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -2,11 +2,14 @@ package nextstep.subway.acceptance;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.applicaion.dto.LineRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import static nextstep.subway.acceptance.LineAcceptanceUtil.*;
+import static nextstep.subway.acceptance.StationAcceptanceUtil.지하철_역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -16,10 +19,19 @@ class LineAcceptanceTest extends AcceptanceTest {
      * When 지하철 노선 생성을 요청 하면
      * Then 지하철 노선 생성이 성공한다.
      */
+
+    @BeforeEach
+    void init() {
+        지하철_역_생성_요청("동암역");
+        지하철_역_생성_요청("강남역");
+        지하철_역_생성_요청("부평역");
+        지하철_역_생성_요청("신촌역");
+    }
+
     @DisplayName("지하철 노선 생성")
     @Test
     void createLine() {
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("신분당선", "bg-red-600");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -34,18 +46,18 @@ class LineAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선 목록 조회")
     @Test
     void getLines() {
+        // given
+        지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
 
         // given
-        지하철_노선_생성_요청("신분당선", "bg-red-600");
-
-        // given
-        지하철_노선_생성_요청("2호선", "bg-red-600");
+        지하철_노선_생성_요청(new LineRequest("2호선", "bg-red-600", 4L, 2L, 10));
 
         // when
         ExtractableResponse<Response> response = 지하철_모든_노선_조회_요청();
 
         // then
-        assertThat(response.jsonPath().getList("name")).containsExactly("신분당선", "2호선");
+        assertThat(response.jsonPath()
+                           .getList("name")).containsExactly("신분당선", "2호선");
     }
 
     /**
@@ -57,12 +69,13 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("신분당선", "bg-red-600");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
         // when
         ExtractableResponse<Response> response2 = 지하철_특정_노선_조회_요청(response);
 
         // then
-        assertThat(response2.jsonPath().getString("name")).isEqualTo("신분당선");
+        assertThat(response2.jsonPath()
+                            .getString("name")).isEqualTo("신분당선");
     }
 
     /**
@@ -75,10 +88,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     void updateLine() {
 
         // given
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "bg-red-600");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("2호선", "bg-red-600", 4L, 2L, 10));
 
         // given
-        지하철_노선_수정_요청(response, "구분당선", "bg-blue-600");
+        지하철_노선_수정_요청(response, new LineRequest("구분당선", "bg-blue-600", 4L, 2L, 10));
 
 
         // when
@@ -86,8 +99,10 @@ class LineAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
-                () -> assertThat(response2.jsonPath().getString("color")).isEqualTo("bg-blue-600"),
-                () -> assertThat(response2.jsonPath().getString("name")).isEqualTo("구분당선")
+                () -> assertThat(response2.jsonPath()
+                                          .getString("color")).isEqualTo("bg-blue-600"),
+                () -> assertThat(response2.jsonPath()
+                                          .getString("name")).isEqualTo("구분당선")
         );
     }
 
@@ -100,7 +115,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("신분당선", "bg-red-600");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
 
         // when
         ExtractableResponse<Response> response2 = 지하철_노선_삭제_요청(response);
@@ -120,10 +135,10 @@ class LineAcceptanceTest extends AcceptanceTest {
     void duplicatedLine() {
 
         // given
-        지하철_노선_생성_요청("신분당선", "bg-red-600");
+        지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
 
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("신분당선", "bg-red-600");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -3,12 +3,14 @@ package nextstep.subway.acceptance;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.SectionRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
 import static nextstep.subway.acceptance.LineAcceptanceUtil.*;
+import static nextstep.subway.acceptance.SectionAcceptanceUtil.지하철_구간_등록_요청;
 import static nextstep.subway.acceptance.StationAcceptanceUtil.지하철_역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -70,12 +72,19 @@ class LineAcceptanceTest extends AcceptanceTest {
     void getLine() {
         // given
         ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
+        String lineLocation = response.header("location");
+        지하철_구간_등록_요청(lineLocation, new SectionRequest("3", "2", 10));
+
         // when
         ExtractableResponse<Response> response2 = 지하철_특정_노선_조회_요청(response);
 
         // then
-        assertThat(response2.jsonPath()
-                            .getString("name")).isEqualTo("신분당선");
+        assertAll(
+                () -> assertThat(response2.jsonPath()
+                                          .getString("name")).isEqualTo("신분당선"),
+                () -> assertThat(response2.jsonPath()
+                                          .getList("stations.name")).containsExactly("신촌역", "강남역", "부평역")
+        );
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceUtil.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceUtil.java
@@ -3,42 +3,37 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.applicaion.dto.LineRequest;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class LineAcceptanceUtil {
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
-        // given
-        Map<String, String> params = new HashMap<>();
-        params.put("color", color);
-        params.put("name", name);
-
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(LineRequest requestBody) {
         // when
         return RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(params)
+                .body(requestBody)
                 .when()
                 .post("/lines")
-                .then().log().all().extract();
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 
-    public static ExtractableResponse<Response> 지하철_노선_수정_요청(ExtractableResponse<Response> response, String name, String color) {
+    public static ExtractableResponse<Response> 지하철_노선_수정_요청(ExtractableResponse<Response> response, LineRequest requestBody) {
         String location = response.header("location");
-
-        Map<String, String> params = new HashMap<>();
-        params.put("color", color);
-        params.put("name", name);
 
         return RestAssured
                 .given()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(params)
+                .body(requestBody)
                 .when()
                 .put(location)
-                .then().log().all().extract();
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 
     public static ExtractableResponse<Response> 지하철_모든_노선_조회_요청() {
@@ -48,7 +43,10 @@ public class LineAcceptanceUtil {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .get("/lines")
-                .then().log().all().extract();
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 
     public static ExtractableResponse<Response> 지하철_특정_노선_조회_요청(ExtractableResponse<Response> response) {
@@ -60,7 +58,10 @@ public class LineAcceptanceUtil {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
                 .get(location)
-                .then().log().all().extract();
+                .then()
+                .log()
+                .all()
+                .extract();
     }
 
     public static ExtractableResponse<Response> 지하철_노선_삭제_요청(ExtractableResponse<Response> response) {
@@ -70,7 +71,10 @@ public class LineAcceptanceUtil {
                 .given()
                 .when()
                 .delete(location)
-                .then().log().all().extract();
+                .then()
+                .log()
+                .all()
+                .extract();
 
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -58,13 +58,15 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선의 구간 제거")
     @Test
     void removeSection() {
-        String deleteDownStationLocation = lineLocation + "/sections?stationId=2";
+        지하철_구간_등록_요청(lineLocation, new SectionRequest("3", "2", 10));
+
+        String deleteDownStationLocation = lineLocation + "/sections?stationId=3";
         ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteDownStationLocation);
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 
-    @DisplayName("지하철 노선에 등록역만 제거할 수 있다.")
+    @DisplayName("지하철 노선에 등록된 역만 제거할 수 있다.")
     @Test
     void removeSection2(){
         String deleteNotExistStationLocation = lineLocation + "/sections?stationId=999999";
@@ -91,4 +93,14 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
+
+    @DisplayName("지하철 노선에 상행 종점역과 하행 종점역만 있는 경우(구간이 1개인 경우) 역을 삭제할 수 없다.")
+    @Test
+    void removeSection5(){
+        String deleteLocation = lineLocation + "/sections?stationId=2";
+        ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteLocation);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -53,4 +53,24 @@ public class SectionAcceptanceTest extends AcceptanceTest {
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
+
+    @DisplayName("새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.")
+    @Test
+    void createSection2() {
+
+        // when: 신구간의 상행역이 등록되어있는 하행 종점역이 아닌 경우
+        SectionRequest requestBody = new SectionRequest("2", "4", 10);
+        ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(requestBody)
+                .when()
+                .post(location + "/sections")
+                .then()
+                .log()
+                .all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -33,7 +33,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선에 구간 생성")
     @Test
     void createSection() {
-        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("4", "2", 10));
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("3", "2", 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
@@ -41,8 +41,16 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.")
     @Test
     void createSection2() {
-        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("2", "4", 10));
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("3", "4", 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.")
+    @Test
+    void createSection3() {
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("4", "2", 10));
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -58,9 +58,37 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선의 구간 제거")
     @Test
     void removeSection() {
-        String deleteSectionLocation = lineLocation + "/sections?stationId=2";
-        ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteSectionLocation);
+        String deleteDownStationLocation = lineLocation + "/sections?stationId=2";
+        ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteDownStationLocation);
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    @DisplayName("지하철 노선에 등록역만 제거할 수 있다.")
+    @Test
+    void removeSection2(){
+        String deleteNotExistStationLocation = lineLocation + "/sections?stationId=999999";
+        ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteNotExistStationLocation);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("지하철 노선에 등록된 하행 종점역만 제거할 수 있다.")
+    @Test
+    void removeSection3(){
+        String deleteUpStationLocation = lineLocation + "/sections?stationId=4";
+        ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteUpStationLocation);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("지하철 노선에 등록된 마지막 구간만 제거할 수 있다.")
+    @Test
+    void removeSection4(){
+        지하철_구간_등록_요청(lineLocation, new SectionRequest("3", "2", 10));
+        String deleteStationLocation = lineLocation + "/sections?stationId=2";
+        ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteStationLocation);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,0 +1,56 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static nextstep.subway.acceptance.LineAcceptanceUtil.지하철_노선_생성_요청;
+import static nextstep.subway.acceptance.StationAcceptanceUtil.지하철_역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("지하철 구간 관리 기능")
+public class SectionAcceptanceTest extends AcceptanceTest {
+
+    private static String location;
+
+    @BeforeEach
+    void init() {
+        지하철_역_생성_요청("동암역");
+        지하철_역_생성_요청("강남역");
+        지하철_역_생성_요청("부평역");
+        지하철_역_생성_요청("신촌역");
+
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
+        location = response.header("location");
+    }
+
+    @DisplayName("지하철 노선에 구간 생성")
+    @Test
+    void createSection() {
+        // given: 역을 생성한다.
+        // and: 노선을 생성한다.
+        // when: 구간 생성을 요청하면
+        // then: 구간 생성이 성공한다.
+
+        SectionRequest requestBody = new SectionRequest("4", "2", 10);
+        ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(requestBody)
+                .when()
+                .post(location + "/sections")
+                .then()
+                .log()
+                .all()
+                .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,6 +1,5 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.applicaion.dto.LineRequest;
@@ -9,9 +8,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import static nextstep.subway.acceptance.LineAcceptanceUtil.지하철_노선_생성_요청;
+import static nextstep.subway.acceptance.SectionAcceptanceUtil.지하철_구간_등록_요청;
 import static nextstep.subway.acceptance.StationAcceptanceUtil.지하철_역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,22 +33,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("지하철 노선에 구간 생성")
     @Test
     void createSection() {
-        // given: 역을 생성한다.
-        // and: 노선을 생성한다.
-        // when: 구간 생성을 요청하면
-        // then: 구간 생성이 성공한다.
-
-        SectionRequest requestBody = new SectionRequest("4", "2", 10);
-        ExtractableResponse<Response> response = RestAssured
-                .given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(requestBody)
-                .when()
-                .post(location + "/sections")
-                .then()
-                .log()
-                .all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("4", "2", 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
@@ -57,19 +41,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.")
     @Test
     void createSection2() {
-
-        // when: 신구간의 상행역이 등록되어있는 하행 종점역이 아닌 경우
-        SectionRequest requestBody = new SectionRequest("2", "4", 10);
-        ExtractableResponse<Response> response = RestAssured
-                .given()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(requestBody)
-                .when()
-                .post(location + "/sections")
-                .then()
-                .log()
-                .all()
-                .extract();
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("2", "4", 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -11,13 +11,14 @@ import org.springframework.http.HttpStatus;
 
 import static nextstep.subway.acceptance.LineAcceptanceUtil.지하철_노선_생성_요청;
 import static nextstep.subway.acceptance.SectionAcceptanceUtil.지하철_구간_등록_요청;
+import static nextstep.subway.acceptance.SectionAcceptanceUtil.지하철_구간_삭제_요청;
 import static nextstep.subway.acceptance.StationAcceptanceUtil.지하철_역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 구간 관리 기능")
 public class SectionAcceptanceTest extends AcceptanceTest {
 
-    private static String location;
+    private static String lineLocation;
 
     @BeforeEach
     void init() {
@@ -27,13 +28,13 @@ public class SectionAcceptanceTest extends AcceptanceTest {
         지하철_역_생성_요청("신촌역");
 
         ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
-        location = response.header("location");
+        lineLocation = response.header("location");
     }
 
     @DisplayName("지하철 노선에 구간 생성")
     @Test
     void createSection() {
-        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("3", "2", 10));
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(lineLocation, new SectionRequest("3", "2", 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
@@ -41,7 +42,7 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.")
     @Test
     void createSection2() {
-        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("3", "4", 10));
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(lineLocation, new SectionRequest("3", "4", 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
@@ -49,8 +50,17 @@ public class SectionAcceptanceTest extends AcceptanceTest {
     @DisplayName("새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.")
     @Test
     void createSection3() {
-        ExtractableResponse<Response> response = 지하철_구간_등록_요청(location, new SectionRequest("4", "2", 10));
+        ExtractableResponse<Response> response = 지하철_구간_등록_요청(lineLocation, new SectionRequest("4", "2", 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+    }
+
+    @DisplayName("지하철 노선의 구간 제거")
+    @Test
+    void removeSection() {
+        String deleteSectionLocation = lineLocation + "/sections?stationId=2";
+        ExtractableResponse<Response> response = 지하철_구간_삭제_요청(deleteSectionLocation);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceUtil.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceUtil.java
@@ -1,0 +1,22 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import org.springframework.http.MediaType;
+
+public class SectionAcceptanceUtil {
+    public static ExtractableResponse<Response> 지하철_구간_등록_요청(String location, SectionRequest requestBody) {
+        return RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(requestBody)
+                .when()
+                .post(location + "/sections")
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceUtil.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceUtil.java
@@ -19,4 +19,15 @@ public class SectionAcceptanceUtil {
                 .all()
                 .extract();
     }
+
+    public static ExtractableResponse<Response> 지하철_구간_삭제_요청(String deleteLocation) {
+        return RestAssured
+                .given()
+                .when()
+                .delete(deleteLocation)
+                .then()
+                .log()
+                .all()
+                .extract();
+    }
 }


### PR DESCRIPTION
개인사정으로 지난주차 과제를 뒤늦게 하게 됐습니다. 

연휴에도 시간 내어 리뷰해주셔서 감사합니다.


## 궁금한 사항 3가지

### 1. Line에서 모든 역을 가져올 때, sectionList를 순회하면서 담았습니다.
   - 라인 구간들의 상행역, 하행역을 순서대로 리스트에 담는 방식인데, 요구사항에서 의도하신 방법이 맞는지 궁금합니다.

```java
@Entity
public class Line extends BaseEntity {

....

    public List<Station> getStations() {
        List<Station> stations = new ArrayList<>();

        for (Section s : sectionList) {
            if(!stations.contains(s.getUpStation())) {
                stations.add(s.getUpStation());
            }
            if(!stations.contains(s.getDownStation())) {
                stations.add(s.getDownStation());
            }
        }

        return stations;
    }
}
```


### 2. 구간을 삭제하는 로직을 아래와 같이 작성했습니다.
 - 모든 구간을 순회하면서 하는 방식이라 비효율적이고 복잡한 데, 리뷰어님이라면 어떤 방식으로 작성 하시는지 궁금합니다!

```java
    @Transactional
    public void delete(Long lineId, Long deleteStationId) {
        Line findLine = lineRepository.findById(lineId)
                                      .orElseThrow(() -> new RuntimeException("해당하는 노선을 찾을 수 없습니다."));


        if(findLine.getSectionList().size() == 1){
            throw new NotRemoveStationException("구간이 1개인 경우 역을 삭제할 수 없다.");
        }

        boolean isExistStation = false;
        for (Section section : findLine.getSectionList()) {
            Long findDownStationId = section.getDownStation()
                                            .getId();
            Long findUpStationId = section.getUpStation()
                                          .getId();

            if (deleteStationId.equals(findUpStationId)) {
                throw new NotRemoveStationException("지하철 노선에 등록된 하행 종점역만 제거할 수 있다.");
            }

            if (deleteStationId.equals(findDownStationId)) {
                isExistStation = true;
            }
        }

        if (!isExistStation) {
            throw new NotRemoveStationException("지하철 노선에 등록된 역만 제거할 수 있다.");
        }


        sectionRepository.deleteByLineIdAndDownStationId(lineId, deleteStationId);
    }
```


### 3.  테스트 케이스마다 given을 제공 해주어야 할지.. 고민입니다. 리뷰어님은 어덯게 생각하시나요?

  - 구간 관리 인수테스트를 작성하는 과정에서, 사전에 중복되는 요청을 BeforeEach로 제거 하였습니다. 
  - 하지만 자칫하면 깨지기 쉬운 테스트가 될수도 있을 것 같다는 생각이 들었습니다.
  
  - 그이유는, 현재 테스트 코드에서 BeforeEach에서 생성한 지하철 역의 아이디를 매직넘버로 사용하고 있기 때문입니다.
     - 향후 실수로 BeforeEach에서 호출하는 메서드의 순서가 변경된다거나 이름이 변경될 수도 있지않을까? 하는 생각이 들었습니다.


```java
@DisplayName("지하철 구간 관리 기능")
public class SectionAcceptanceTest extends AcceptanceTest {

    private static String lineLocation;

    @BeforeEach
    void init() {
        지하철_역_생성_요청("동암역");
        지하철_역_생성_요청("강남역");
        지하철_역_생성_요청("부평역");
        지하철_역_생성_요청("신촌역");

        ExtractableResponse<Response> response = 지하철_노선_생성_요청(new LineRequest("신분당선", "bg-red-600", 4L, 2L, 10));
        lineLocation = response.header("location");
    }

    @DisplayName("지하철 노선에 구간 생성")
    @Test
    void createSection() {
        ExtractableResponse<Response> response = 지하철_구간_등록_요청(lineLocation, new SectionRequest("3", "2", 10));

        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
    }
....
}
```
