### PR TITLE
1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -50,13 +50,13 @@ public class StationAcceptanceTest {
         ExtractableResponse<Response> response =
                 RestAssured.given().log().all()
                         .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .contentType(APPLICATION_JSON_VALUE)
                         .when().post("/stations")
                         .then().log().all()
                         .extract();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(response.statusCode()).isEqualTo(CREATED.value());
 
         // then
         List<String> stationNames =
@@ -64,7 +64,9 @@ public class StationAcceptanceTest {
                         .when().get("/stations")
                         .then().log().all()
                         .extract().jsonPath().getList("name", String.class);
-        assertThat(stationNames).containsAnyOf("강남역");
+
+        assertThat(stationNames.size()).isEqualTo(params.size());
+        assertThat(stationNames).containsAll(params.values());
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -3,36 +3,41 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class StationAcceptanceTest {
 
+    @LocalServerPort
+    int port;
     @Autowired
     private StationRepository stationRepository;
 
-    @LocalServerPort
-    int port;
-
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         RestAssured.port = port;
+    }
+
+    @AfterEach
+    void tearDown() {
+        stationRepository.deleteAll();
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -79,22 +79,41 @@ public class StationAcceptanceTest {
     @Test
     void getStations() throws Exception {
         // given
-        final Station gangnamStation = new Station("강남역");
-        final Station samsungStation = new Station("삼성역");
-        stationRepository.saveAll(List.of(gangnamStation, samsungStation));
+        // 생성할 역 이름 리스트
+        final List<String> stations = new ArrayList<>();
+        stations.add("강남역");
+        stations.add("역삼역");
+
+        // 생성해야할 리스트의 길이만큼 반복문을 돌며 역을 생성합니다
+        for (final String station : stations) {
+            final HashMap<String, String> param = new HashMap<>();
+            param.put("name", station);
+
+            final ExtractableResponse<Response> createStationResponse = RestAssured
+                    .given().log().all()
+                    .body(param)
+                    .contentType(APPLICATION_JSON_VALUE)
+                    .when().post("/stations")
+                    .then()
+                    .extract();
+
+            assertThat(createStationResponse.statusCode()).isEqualTo(CREATED.value());
+        }
 
         // when
-        final ExtractableResponse<Response> response = RestAssured.given().log().all()
+        final ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
                 .when().get("/stations")
                 .then().log().all()
                 .extract();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(response.statusCode()).isEqualTo(OK.value());
 
         // then
         final List<String> stationNames = response.jsonPath().getList("name", String.class);
         assertThat(stationNames.size()).isEqualTo(2);
+        assertThat(stationNames).contains("강남역", "역삼역");
     }
 
     /**

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -126,23 +126,39 @@ public class StationAcceptanceTest {
     @Test
     void deleteStations() throws Exception {
         // given
-        final Station savedStation = stationRepository.save(new Station("강남역"));
+        final HashMap<String, String> param = new HashMap<>();
+        param.put("name", "강남역");
+
+        final ExtractableResponse<Response> createStationResponse = RestAssured
+                .given().log().all()
+                .body(param)
+                .contentType(APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then()
+                .extract();
+
+        assertThat(createStationResponse.statusCode()).isEqualTo(CREATED.value());
+
+        // 저장된 지하철 역의 ID
+        final String savedStationId = createStationResponse.jsonPath().getString("id");
 
         // when
-        final ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .when().delete("/stations/" + savedStation.getId())
+        final ExtractableResponse<Response> response = RestAssured
+                .given().log().all()
+                .when().delete("/stations/" + savedStationId)
                 .then().log().all()
                 .extract();
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(response.statusCode()).isEqualTo(NO_CONTENT.value());
 
         // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
+        List<String> stationNames = RestAssured
+                .given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+
         assertThat(stationNames.size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
### 개발 내용
- 지하철역 생성에 대한 테스트 코드의 검증 부분(then) 을 리팩토링합니다.
- 지하철역 목록 조회에 대한 테스트 코드의 에러를 수정합니다.
- 지하철역 삭제에 대한 테스트 코드의 given 부분을 repository 를 사용하지 않는 방식으로 변경합니다.
- 전체 테스트의 통과를 위하여 매 테스트 함수가 종료되는 시점에 repository 를 초기화해줍니다.