### PR TITLE
1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -3,29 +3,33 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import nextstep.subway.domain.StationRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class StationAcceptanceTest {
     @LocalServerPort
     int port;
 
+    @Autowired
+    StationRepository stationRepository;
+
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+        stationRepository.deleteAll();
     }
 
     /**
@@ -35,29 +39,17 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 생성한다.")
     @Test
+    @Order(1)
     void createStation() {
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = makeStation(Map.of("name", "역삼역"));
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-        assertThat(stationNames).containsAnyOf("강남역");
+        List<String> stationNames = getStationNames();
+        assertThat(stationNames).containsAnyOf("역삼역");
     }
 
     /**
@@ -65,10 +57,19 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
     @DisplayName("지하철역을 조회한다.")
     @Test
+    @Order(2)
     void getStations() {
+        // when
+        makeStation(Map.of("name", "선릉역"));
+        makeStation(Map.of("name", "삼성역"));
+
+        // when
+        List<String> stationNames = getStationNames();
+
+        // then
+        assertThat(stationNames).hasSize(2).contains("삼성역", "선릉역");
     }
 
     /**
@@ -76,9 +77,40 @@ public class StationAcceptanceTest {
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
     @DisplayName("지하철역을 제거한다.")
     @Test
+    @Order(3)
     void deleteStation() {
+        // given
+        Long id = makeStation(Map.of("name", "강남역")).jsonPath().getLong("id");
+
+        // when
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .when().delete("/stations/{id}", id)
+                        .then().log().all()
+                        .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
+        List<String> stationNames = getStationNames();
+        assertThat(stationNames).doesNotContain("강남역");
+    }
+
+    ExtractableResponse<Response> makeStation(Map<String, String> params) {
+        return RestAssured.given().log().all()
+                        .body(params)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/stations")
+                        .then().log().all()
+                        .extract();
+    }
+
+    List<String> getStationNames() {
+        return RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
     }
 }


### PR DESCRIPTION
### Summary
지하철역 인수 테스트 작성
- 지하철역 목록 조회 인수 테스트
- 지하철역 삭제 인수 테스트

### Comment
- 강의 마지막에 말씀하신 '생성->조회 순으로 테스트를 하면 실패한다.' 가 너무 인상깊게 남아서, 순서를 고려하지 않고 구현하라는 요구사항을 제대로 지키지 못했네요.
- `makeStationAndVerify()`에서 `assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());`의 위치를 어떻게 잡아야 할 지 모르겠습니다. (`getStationNamesAndVerify()`도 동일합니다.)
    1. 현재 위치에 그대로 둘지
    2. 호출할 때마다 `@Test` 함수에서 검증할지
- 저는 호출할 때마다 검증하는 것이 맞다고 생각해서 1번으로 했습니다.(조회 test에서 실패하면 어디서 실패했는지 명확하게 하기 위해, 호출할 때마다 statuscode 검증하는 것은 코드 중복이 심한 것 같아서) 리뷰어님의 생각이 궁금합니다.