### PR TITLE
2단계 - 지하철 노선 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.6.3'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id "io.freefair.lombok" version "6.5.0.2"
     id 'java'
 }
 

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -2,8 +2,8 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
-import nextstep.subway.domain.Station;
-import nextstep.subway.domain.StationRepository;
+import nextstep.subway.domain.station.Station;
+import nextstep.subway.domain.station.StationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
 @Service
 @Transactional(readOnly = true)
 public class StationService {
-    private StationRepository stationRepository;
+    private final StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;

--- a/src/main/java/nextstep/subway/applicaion/dto/LineCreationRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineCreationRequest.java
@@ -1,0 +1,29 @@
+package nextstep.subway.applicaion.dto;
+
+public class LineCreationRequest {
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private Long distance;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Long getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineCreationRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineCreationRequest.java
@@ -1,29 +1,21 @@
 package nextstep.subway.applicaion.dto;
 
+import lombok.Getter;
+
+@Getter
 public class LineCreationRequest {
-    private String name;
-    private String color;
-    private Long upStationId;
-    private Long downStationId;
-    private Long distance;
+    private final String name;
+    private final String color;
+    private final Long upStationId;
+    private final Long downStationId;
+    private final Long distance;
 
-    public String getName() {
-        return name;
-    }
-
-    public String getColor() {
-        return color;
-    }
-
-    public Long getUpStationId() {
-        return upStationId;
-    }
-
-    public Long getDownStationId() {
-        return downStationId;
-    }
-
-    public Long getDistance() {
-        return distance;
+    public LineCreationRequest(String name, String color, Long upStationId,
+            Long downStationId, Long distance) {
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineModificationRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineModificationRequest.java
@@ -1,0 +1,14 @@
+package nextstep.subway.applicaion.dto;
+
+import lombok.Getter;
+
+@Getter
+public class LineModificationRequest {
+    private final String name;
+    private final String color;
+
+    public LineModificationRequest(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,0 +1,30 @@
+package nextstep.subway.applicaion.dto;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.Getter;
+import nextstep.subway.domain.line.Line;
+
+@Getter
+public class LineResponse {
+    private final Long id;
+    private final String name;
+    private final String color;
+    private final List<StationResponse> stations;
+
+    public LineResponse(Long id, String name, String color, List<StationResponse> stations) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.stations = stations;
+    }
+
+    public static LineResponse fromLine(Line line) {
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                Collections.emptyList()
+        );
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/line/LineCreator.java
+++ b/src/main/java/nextstep/subway/applicaion/line/LineCreator.java
@@ -1,0 +1,31 @@
+package nextstep.subway.applicaion.line;
+
+import nextstep.subway.applicaion.dto.LineCreationRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.domain.line.Line;
+import nextstep.subway.domain.line.LineRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LineCreator {
+
+    private final LineRepository lineRepository;
+
+    public LineCreator(LineRepository lineRepository) {
+        this.lineRepository = lineRepository;
+    }
+
+    @Transactional
+    public LineResponse create(LineCreationRequest request) {
+        var line = new Line(
+                null,
+                request.getName(),
+                request.getColor(),
+                request.getUpStationId(),
+                request.getDownStationId(),
+                request.getDistance());
+
+        return LineResponse.fromLine(lineRepository.save(line));
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/line/LineModifier.java
+++ b/src/main/java/nextstep/subway/applicaion/line/LineModifier.java
@@ -1,0 +1,30 @@
+package nextstep.subway.applicaion.line;
+
+import nextstep.subway.applicaion.dto.LineModificationRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.domain.exception.DomainException;
+import nextstep.subway.domain.exception.DomainExceptionType;
+import nextstep.subway.domain.line.LineRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LineModifier {
+
+    private final LineRepository lineRepository;
+
+    public LineModifier(LineRepository lineRepository) {
+        this.lineRepository = lineRepository;
+    }
+
+    @Transactional
+    public LineResponse modify(Long lineId, LineModificationRequest request) {
+        var line = lineRepository.findById(lineId)
+                .orElseThrow(() -> new DomainException(DomainExceptionType.LINE_NOT_FOUND));
+
+        line.setName(request.getName());
+        line.setColor(request.getColor());
+
+        return LineResponse.fromLine(line);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/line/LineQueryService.java
+++ b/src/main/java/nextstep/subway/applicaion/line/LineQueryService.java
@@ -1,0 +1,26 @@
+package nextstep.subway.applicaion.line;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.domain.line.LineRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class LineQueryService {
+
+    private final LineRepository lineRepository;
+
+    public LineQueryService(LineRepository lineRepository) {
+        this.lineRepository = lineRepository;
+    }
+
+    public List<LineResponse> getAllLines() {
+        return lineRepository.findAll()
+                .stream()
+                .map(LineResponse::fromLine)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/line/LineQueryService.java
+++ b/src/main/java/nextstep/subway/applicaion/line/LineQueryService.java
@@ -3,6 +3,8 @@ package nextstep.subway.applicaion.line;
 import java.util.List;
 import java.util.stream.Collectors;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.domain.exception.DomainException;
+import nextstep.subway.domain.exception.DomainExceptionType;
 import nextstep.subway.domain.line.LineRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,5 +24,11 @@ public class LineQueryService {
                 .stream()
                 .map(LineResponse::fromLine)
                 .collect(Collectors.toList());
+    }
+
+    public LineResponse getLineById(Long id) {
+        return lineRepository.findById(id)
+                .map(LineResponse::fromLine)
+                .orElseThrow(() -> new DomainException(DomainExceptionType.LINE_NOT_FOUND));
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/line/LineRemover.java
+++ b/src/main/java/nextstep/subway/applicaion/line/LineRemover.java
@@ -1,0 +1,20 @@
+package nextstep.subway.applicaion.line;
+
+import nextstep.subway.domain.line.LineRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class LineRemover {
+
+    private final LineRepository lineRepository;
+
+    public LineRemover(LineRepository lineRepository) {
+        this.lineRepository = lineRepository;
+    }
+
+    @Transactional
+    public void remove(Long lineId) {
+        lineRepository.deleteById(lineId);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/DomainException.java
+++ b/src/main/java/nextstep/subway/domain/exception/DomainException.java
@@ -1,0 +1,23 @@
+package nextstep.subway.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DomainException extends RuntimeException {
+
+    private final String message;
+    private final HttpStatus status;
+
+    public DomainException(DomainExceptionType type) {
+        this.message = type.getMessage();
+        this.status = type.getStatus();
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/exception/DomainExceptionType.java
+++ b/src/main/java/nextstep/subway/domain/exception/DomainExceptionType.java
@@ -1,0 +1,25 @@
+package nextstep.subway.domain.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum DomainExceptionType {
+
+    LINE_NOT_FOUND("없는 노선 ID 입니다.", HttpStatus.NOT_FOUND)
+    ;
+
+    private final String message;
+    private final HttpStatus status;
+
+    DomainExceptionType(String message, HttpStatus status) {
+        this.message = message;
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/line/Line.java
+++ b/src/main/java/nextstep/subway/domain/line/Line.java
@@ -1,0 +1,33 @@
+package nextstep.subway.domain.line;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class Line {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private Long distance;
+
+    public Line() {}
+
+    public Line(Long id, String name, String color, Long upStationId, Long downStationId, Long distance) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/line/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/line/LineRepository.java
@@ -1,0 +1,6 @@
+package nextstep.subway.domain.line;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+}

--- a/src/main/java/nextstep/subway/domain/line/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/line/LineRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
     Optional<Line> findById(Long id);
+    void deleteById(Long id);
 }

--- a/src/main/java/nextstep/subway/domain/line/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/line/LineRepository.java
@@ -1,6 +1,8 @@
 package nextstep.subway.domain.line;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LineRepository extends JpaRepository<Line, Long> {
+    Optional<Line> findById(Long id);
 }

--- a/src/main/java/nextstep/subway/domain/station/Station.java
+++ b/src/main/java/nextstep/subway/domain/station/Station.java
@@ -1,4 +1,4 @@
-package nextstep.subway.domain;
+package nextstep.subway.domain.station;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;

--- a/src/main/java/nextstep/subway/domain/station/StationRepository.java
+++ b/src/main/java/nextstep/subway/domain/station/StationRepository.java
@@ -1,4 +1,4 @@
-package nextstep.subway.domain;
+package nextstep.subway.domain.station;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -8,6 +8,7 @@ import nextstep.subway.applicaion.line.LineCreator;
 import nextstep.subway.applicaion.line.LineQueryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -30,6 +31,11 @@ public class LineController {
     public ResponseEntity<List<LineResponse>> getLines() {
         var lines = lineQueryService.getAllLines();
         return ResponseEntity.ok(lines);
+    }
+
+    @GetMapping("/lines/{lineId}")
+    public ResponseEntity<LineResponse> getLineById(@PathVariable("lineId") Long lineId) {
+        return ResponseEntity.ok(lineQueryService.getLineById(lineId));
     }
 
     @PostMapping("/lines")

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,10 +1,13 @@
 package nextstep.subway.ui;
 
 import java.net.URI;
+import java.util.List;
 import nextstep.subway.applicaion.dto.LineCreationRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.line.LineCreator;
+import nextstep.subway.applicaion.line.LineQueryService;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,9 +16,20 @@ import org.springframework.web.bind.annotation.RestController;
 public class LineController {
 
     private final LineCreator lineCreator;
+    private final LineQueryService lineQueryService;
 
-    public LineController(LineCreator lineCreator) {
+    public LineController(
+            LineCreator lineCreator,
+            LineQueryService lineQueryService
+    ) {
         this.lineCreator = lineCreator;
+        this.lineQueryService = lineQueryService;
+    }
+
+    @GetMapping("/lines")
+    public ResponseEntity<List<LineResponse>> getLines() {
+        var lines = lineQueryService.getAllLines();
+        return ResponseEntity.ok(lines);
     }
 
     @PostMapping("/lines")

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -8,7 +8,9 @@ import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.line.LineCreator;
 import nextstep.subway.applicaion.line.LineModifier;
 import nextstep.subway.applicaion.line.LineQueryService;
+import nextstep.subway.applicaion.line.LineRemover;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,15 +23,18 @@ public class LineController {
 
     private final LineCreator lineCreator;
     private final LineModifier lineModifier;
+    private final LineRemover lineRemover;
     private final LineQueryService lineQueryService;
 
     public LineController(
             LineCreator lineCreator,
             LineModifier lineModifier,
+            LineRemover lineRemover,
             LineQueryService lineQueryService
     ) {
         this.lineCreator = lineCreator;
         this.lineModifier = lineModifier;
+        this.lineRemover = lineRemover;
         this.lineQueryService = lineQueryService;
     }
 
@@ -57,5 +62,11 @@ public class LineController {
     ) {
         lineModifier.modify(lineId, request);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/lines/{lineId}")
+    public ResponseEntity<Void> deleteLine(@PathVariable("lineId") Long lineId) {
+        lineRemover.remove(lineId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,0 +1,26 @@
+package nextstep.subway.ui;
+
+import java.net.URI;
+import nextstep.subway.applicaion.dto.LineCreationRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.line.LineCreator;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LineController {
+
+    private final LineCreator lineCreator;
+
+    public LineController(LineCreator lineCreator) {
+        this.lineCreator = lineCreator;
+    }
+
+    @PostMapping("/lines")
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineCreationRequest request) {
+        var line = lineCreator.create(request);
+        return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+    }
+}

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -3,13 +3,16 @@ package nextstep.subway.ui;
 import java.net.URI;
 import java.util.List;
 import nextstep.subway.applicaion.dto.LineCreationRequest;
+import nextstep.subway.applicaion.dto.LineModificationRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.line.LineCreator;
+import nextstep.subway.applicaion.line.LineModifier;
 import nextstep.subway.applicaion.line.LineQueryService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,13 +20,16 @@ import org.springframework.web.bind.annotation.RestController;
 public class LineController {
 
     private final LineCreator lineCreator;
+    private final LineModifier lineModifier;
     private final LineQueryService lineQueryService;
 
     public LineController(
             LineCreator lineCreator,
+            LineModifier lineModifier,
             LineQueryService lineQueryService
     ) {
         this.lineCreator = lineCreator;
+        this.lineModifier = lineModifier;
         this.lineQueryService = lineQueryService;
     }
 
@@ -42,5 +48,14 @@ public class LineController {
     public ResponseEntity<LineResponse> createLine(@RequestBody LineCreationRequest request) {
         var line = lineCreator.create(request);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+    }
+
+    @PutMapping("/lines/{lineId}")
+    public ResponseEntity<Void> modifyLine(
+            @PathVariable("lineId") Long lineId,
+            @RequestBody LineModificationRequest request
+    ) {
+        lineModifier.modify(lineId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/nextstep/subway/ui/config/ControllerExceptionHandler.java
+++ b/src/main/java/nextstep/subway/ui/config/ControllerExceptionHandler.java
@@ -1,0 +1,17 @@
+package nextstep.subway.ui.config;
+
+import nextstep.subway.domain.exception.DomainException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ExceptionResponse> domainExceptionHandler(DomainException exception) {
+        return ResponseEntity
+                .status(exception.getStatus())
+                .body(new ExceptionResponse(exception.getMessage()));
+    }
+}

--- a/src/main/java/nextstep/subway/ui/config/ExceptionResponse.java
+++ b/src/main/java/nextstep/subway/ui/config/ExceptionResponse.java
@@ -1,0 +1,14 @@
+package nextstep.subway.ui.config;
+
+public class ExceptionResponse {
+
+    private final String message;
+
+    public ExceptionResponse(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AcceptanceTest.java
@@ -1,0 +1,35 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import nextstep.subway.domain.line.LineRepository;
+import nextstep.subway.domain.station.StationRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public abstract class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private LineRepository lineRepository;
+
+    @Autowired
+    private StationRepository stationRepository;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    @AfterEach
+    void cleanUp() {
+        lineRepository.deleteAll();
+        stationRepository.deleteAll();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -4,12 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.restassured.RestAssured;
-import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.HashMap;
 import java.util.Map;
-import nextstep.subway.applicaion.dto.LineCreationRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 @DisplayName("노선 관련 기능")
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -70,9 +68,10 @@ class LineAcceptanceTest {
         return RestAssured
                 .given()
                     .body(requestBody)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().log().all()
                     .post("/lines")
-                .then()
+                .then().log().all()
                     .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -57,6 +57,36 @@ class LineAcceptanceTest {
         );
     }
 
+    /**
+     * Given 2개의 지하철 노선을 생성하고
+     * When 지하철 노선 목록을 조회하면
+     * Then 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다.
+     */
+    @DisplayName("지하철노선 목록 조회")
+    @Test
+    void canFindSameNumberOfLinesWhenLinesWereCreated() {
+        // given
+        createLine(sinbundangLineCreationRequest);
+        createLine(bundangLineCreationRequest);
+
+        // when
+        var lineQueryResponse = RestAssured
+                .when()
+                    .get("/lines")
+                .then()
+                    .extract();
+        var lineNames = lineQueryResponse.jsonPath().getList("name");
+
+        // then
+        assertAll(
+                () -> assertThat(lineQueryResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(lineNames).containsExactlyInAnyOrder(
+                        sinbundangLineCreationRequest.getName(),
+                        bundangLineCreationRequest.getName()
+                )
+        );
+    }
+
     private ExtractableResponse<Response> createLine(LineCreationRequest creationRequest) {
         return RestAssured
                 .given()

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -4,9 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import io.restassured.RestAssured;
+import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Map;
+import nextstep.subway.applicaion.dto.LineCreationRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,11 @@ class LineAcceptanceTest {
     @LocalServerPort
     private int port;
 
+    private final LineCreationRequest sinbundangLineCreationRequest = new LineCreationRequest(
+            "신분당선", "bg-red-600", 1L, 2L, 10L);
+    private final LineCreationRequest bundangLineCreationRequest = new LineCreationRequest(
+            "분당선", "bg-green-600", 1L, 3L, 20L);
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
@@ -36,12 +42,7 @@ class LineAcceptanceTest {
     @Test
     void canFindTheLineCreatedWhenLineWasCreated() {
         // when
-        var lineName = "신분당선";
-        var lineColor = "bg-red-600";
-        var upStationId = 1L;
-        var downStationId = 2L;
-        var distance = 10L;
-        var creationResponse = createLine(lineName, lineColor, upStationId, downStationId, distance);
+        var creationResponse = createLine(sinbundangLineCreationRequest);
 
         // then
         var lineNames = RestAssured
@@ -52,26 +53,18 @@ class LineAcceptanceTest {
 
         assertAll(
                 () -> assertThat(creationResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                () -> assertThat(lineNames).containsExactlyInAnyOrder(lineName)
+                () -> assertThat(lineNames).containsExactlyInAnyOrder(sinbundangLineCreationRequest.getName())
         );
     }
 
-    private ExtractableResponse<Response> createLine(String name, String color, Long upStationId, Long downStationId, Long distance) {
-        var requestBody = Map.of(
-                "name", name,
-                "color", color,
-                "upStationId", upStationId,
-                "downStationId", downStationId,
-                "distance", distance
-        );
-
+    private ExtractableResponse<Response> createLine(LineCreationRequest creationRequest) {
         return RestAssured
                 .given()
-                    .body(requestBody)
+                    .body(creationRequest, ObjectMapperType.JACKSON_2)
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().log().all()
+                .when()
                     .post("/lines")
-                .then().log().all()
+                .then()
                     .extract();
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,0 +1,78 @@
+package nextstep.subway.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import io.restassured.RestAssured;
+import io.restassured.mapper.ObjectMapperType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import nextstep.subway.applicaion.dto.LineCreationRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+
+@DisplayName("노선 관련 기능")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class LineAcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
+    /**
+     * When 지하철 노선을 생성하면
+     * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
+     */
+    @DisplayName("지하철 노선 생성")
+    @Test
+    void canFindTheLineCreatedWhenLineWasCreated() {
+        // when
+        var lineName = "신분당선";
+        var lineColor = "bg-red-600";
+        var upStationId = 1L;
+        var downStationId = 2L;
+        var distance = 10L;
+        var creationResponse = createLine(lineName, lineColor, upStationId, downStationId, distance);
+
+        // then
+        var lineNames = RestAssured
+                .when()
+                    .get("/lines")
+                .then()
+                    .extract().jsonPath().getList("name", String.class);
+
+        assertAll(
+                () -> assertThat(creationResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                () -> assertThat(lineNames).containsExactlyInAnyOrder(lineName)
+        );
+    }
+
+    private ExtractableResponse<Response> createLine(String name, String color, Long upStationId, Long downStationId, Long distance) {
+        var requestBody = Map.of(
+                "name", name,
+                "color", color,
+                "upStationId", upStationId,
+                "downStationId", downStationId,
+                "distance", distance
+        );
+
+        return RestAssured
+                .given()
+                    .body(requestBody)
+                .when().log().all()
+                    .post("/lines")
+                .then()
+                    .extract();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -9,32 +9,18 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.applicaion.dto.LineCreationRequest;
 import nextstep.subway.applicaion.dto.LineModificationRequest;
-import nextstep.subway.applicaion.dto.LineResponse;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("노선 관련 기능")
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-class LineAcceptanceTest {
-
-    @LocalServerPort
-    private int port;
+class LineAcceptanceTest extends AcceptanceTest {
 
     private final LineCreationRequest sinbundangLineCreationRequest = new LineCreationRequest(
             "신분당선", "bg-red-600", 1L, 2L, 10L);
     private final LineCreationRequest bundangLineCreationRequest = new LineCreationRequest(
             "분당선", "bg-green-600", 1L, 3L, 20L);
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
 
     /**
      * When 지하철 노선을 생성하면

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -2,6 +2,7 @@ package nextstep.subway.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.restassured.RestAssured;
 import io.restassured.mapper.ObjectMapperType;
@@ -136,6 +137,36 @@ class LineAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(modificationResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(modifiedName).isEqualTo(modificationRequest.getName()),
                 () -> assertThat(modifiedColor).isEqualTo(modificationRequest.getColor())
+        );
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 삭제하면
+     * Then 해당 지하철 노선 정보는 삭제된다
+     */
+    @DisplayName("지하철노선 삭제")
+    @Test
+    void removeCreatedLine() {
+        // given
+        var creationResponse = createLine(bundangLineCreationRequest);
+        var createdLineId = creationResponse.jsonPath().getLong("id");
+
+        // when
+        var deleteResponse = RestAssured
+                .given()
+                    .pathParam("lineId", createdLineId)
+                .when()
+                    .delete("/lines/{lineId}")
+                .then()
+                    .extract();
+
+        // then
+        var lineQueryResponse = getLine(createdLineId);
+
+        assertAll(
+                () -> assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+                () -> assertThat(lineQueryResponse.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value())
         );
     }
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -8,6 +8,7 @@ import io.restassured.mapper.ObjectMapperType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.applicaion.dto.LineCreationRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,40 @@ class LineAcceptanceTest {
                         sinbundangLineCreationRequest.getName(),
                         bundangLineCreationRequest.getName()
                 )
+        );
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 조회하면
+     * Then 생성한 지하철 노선의 정보를 응답받을 수 있다.
+     */
+    @DisplayName("지하철노선 조회")
+    @Test
+    void canGetResponseOfLineInformationByLineId() {
+        // given
+        var creationResponse = createLine(bundangLineCreationRequest);
+        var createdLineId = creationResponse.body().jsonPath().getLong("id");
+
+        // when
+        var lineQueryResponse = RestAssured
+                .given()
+                    .pathParam("lineId", createdLineId)
+                .when()
+                    .get("/lines/{lineId}")
+                .then()
+                    .extract();
+
+        // then
+        var id = lineQueryResponse.jsonPath().getLong("id");
+        var name = lineQueryResponse.jsonPath().getString("name");
+        var color = lineQueryResponse.jsonPath().getString("color");
+
+        assertAll(
+                () -> assertThat(lineQueryResponse.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(id).isEqualTo(createdLineId),
+                () -> assertThat(name).isEqualTo(bundangLineCreationRequest.getName()),
+                () -> assertThat(color).isEqualTo(bundangLineCreationRequest.getColor())
         );
     }
 

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -7,24 +7,13 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.HashMap;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 @DisplayName("지하철역 관련 기능")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class StationAcceptanceTest {
-    @LocalServerPort
-    int port;
-
-    @BeforeEach
-    public void setUp() {
-        RestAssured.port = port;
-    }
+class StationAcceptanceTest extends AcceptanceTest {
 
     /**
      * When 지하철역을 생성하면


### PR DESCRIPTION
## Summary

다음 인수 테스트를 작성하고 이에 필요한 기능을 구현했습니다.

* 지하철 노선 생성
* 지하철 노선 목록 조회
* 지하철 노선 조회
* 지하철 노선 수정
* 지하철 노선 삭제

그외 추가 변경사항 및 참고사항

* 테스트 격리 및 중복 fixture 제거를 위한 base test class 작성
* 도메인 예외 정의 및 도메인 예외 핸들러 추가
* 1단계 리뷰 반영 (restassured request body 에 object mapper 활용, hard-coded 테스트 변수 제거)
* 이번 단계의 API 명세에는 노선에 매핑된 역에 대한 정보가 노출되었지만 구체적인 관계 정보에 대한 정의는 나와있지 않아 작성한 도메인 코드 및 응답에서는 별도로 이에 대한 관계를 정의하지 않고 빈 리스트를 반환하도록 하였습니다.

## Comments

안녕하세요 리뷰어님!

이번 인수 테스트를 구현할 때에는 개별 인수테스트마다 테스트를 작성하고 구현하는 방식으로 개발하였는데요
혹시 모든 인수 테스트를 작성하고 나서 세부 기능을 구현해나가야 하는 것인지 잠시 고민이 되었지만 개별 테스트를 PASS 시키고 나서
다음 작업을 진행하는 것이 낫다고 판단해서 이러한 방식으로 진행하게 되었습니다. 여러개의 인수 테스트가 존재할 때 리뷰어님은 어떤 방식으로 개발을 진행하시는지 궁금합니다.

지난번 리뷰주신 사항대로 request body 를 작성할 때 HashMap 대신 기존에 존재하는 DTO 객체를 활용하는 방향으로 변경해 보았는데요,
확실히 body 가 복잡해질수록 테스트 코드의 가독성이나 작성의 편의 면에서 편리함이 있어 좋았습니다. 하지만 한편으로는 HTTP API 레벨의 테스트를 하는 상황에서 내부 코드를 활용하는것이 구현과 테스트의 결합을 높이진 않을까 하는 걱정도 들었는데요 리뷰어님의 의견은 어떠신지 궁금합니다!
