### PR TITLE
Step2 - 지하철 노선 기능

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -2,12 +2,14 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.LineUpdateDto;
 import nextstep.subway.applicaion.dto.StationResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,6 +53,15 @@ public class LineService {
                 .collect(Collectors.toList());
     }
 
+    public Line findLine(Long lineId) {
+        return lineRepository.findById(lineId).orElseThrow(() -> new EntityNotFoundException(lineId + "번 id로 조회되는 노선이 없습니다."));
+    }
 
+    @Transactional
+    public void updateLine(Long id, LineUpdateDto updateDto) {
+        Line line = findLine(id);
+        line.updateLine(updateDto);
 
+        lineRepository.save(line);
+    }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -2,34 +2,45 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.StationResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Service
 @Transactional(readOnly = true)
 public class LineService {
     private LineRepository lineRepository;
+    private StationService stationService;
 
-    public LineService(LineRepository lineRepository) {
+    public LineService(LineRepository lineRepository, StationService stationService) {
         this.lineRepository = lineRepository;
+        this.stationService = stationService;
     }
 
     @Transactional
     public LineResponse saveLine(LineRequest lineRequest) {
         Line line = lineRepository.save(new Line(lineRequest.getName(), lineRequest.getColor(), lineRequest.getUpStationId(), lineRequest.getDownStationId(), lineRequest.getDistance()));
-        return createLineResponse(line);
+        LineResponse lineResponse = createLineResponse(line);
+
+        return lineResponse;
     }
 
     private LineResponse createLineResponse(Line line) {
+        List<StationResponse> stationResponses = new ArrayList<>();
+
+        stationResponses.add(stationService.createStationResponse(line.getUpStationId()));
+        stationResponses.add(stationService.createStationResponse(line.getDownStationId()));
+
         return new LineResponse(
                 line.getId(),
                 line.getName(),
                 line.getColor(),
-                line.getUpStationId(),
-                line.getDownStationId(),
-                line.getDistance()
+                stationResponses
         );
     }
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
@@ -43,5 +44,13 @@ public class LineService {
                 stationResponses
         );
     }
+
+    public List<LineResponse> findAllLines() {
+        return lineRepository.findAll().stream()
+                .map(this::createLineResponse)
+                .collect(Collectors.toList());
+    }
+
+
 
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -64,4 +64,11 @@ public class LineService {
 
         lineRepository.save(line);
     }
+
+    @Transactional
+    public void deleteLine(Long id) {
+        Line line = findLine(id);
+
+        lineRepository.delete(line);
+    }
 }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -1,0 +1,36 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.LineRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class LineService {
+    private LineRepository lineRepository;
+
+    public LineService(LineRepository lineRepository) {
+        this.lineRepository = lineRepository;
+    }
+
+    @Transactional
+    public LineResponse saveLine(LineRequest lineRequest) {
+        Line line = lineRepository.save(new Line(lineRequest.getName(), lineRequest.getColor(), lineRequest.getUpStationId(), lineRequest.getDownStationId(), lineRequest.getDistance()));
+        return createLineResponse(line);
+    }
+
+    private LineResponse createLineResponse(Line line) {
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                line.getUpStationId(),
+                line.getDownStationId(),
+                line.getDistance()
+        );
+    }
+
+}

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -7,6 +7,7 @@ import nextstep.subway.domain.StationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import javax.persistence.EntityNotFoundException;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,11 @@ public class StationService {
         return stationRepository.findAll().stream()
                 .map(this::createStationResponse)
                 .collect(Collectors.toList());
+    }
+
+    public StationResponse createStationResponse(Long stationId) {
+        return stationRepository.findById(stationId).map(StationResponse::new)
+                .orElseThrow(() -> new EntityNotFoundException(stationId + "번 id로 조회되는 역이 없습니다."));
     }
 
     @Transactional

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -8,6 +8,18 @@ public class LineRequest {
     private Long downStationId;
     private Integer distance;
 
+    public LineRequest() {
+
+    }
+
+    public LineRequest(String name, String color, Long upStationId, Long downStationId, Integer distance) {
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
     public String getName() {
         return name;
     }
@@ -27,4 +39,5 @@ public class LineRequest {
     public int getDistance() {
         return distance;
     }
+
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -4,10 +4,9 @@ public class LineRequest {
 
     private String name;
     private String color;
-    private long upStationId;
-    private long downStationId;
-    private int distance;
-
+    private Long upStationId;
+    private Long downStationId;
+    private Integer distance;
 
     public String getName() {
         return name;

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -1,0 +1,31 @@
+package nextstep.subway.applicaion.dto;
+
+public class LineRequest {
+
+    private String name;
+    private String color;
+    private long upStationId;
+    private long downStationId;
+    private int distance;
+
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public long getUpStationId() {
+        return upStationId;
+    }
+
+    public long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,0 +1,43 @@
+package nextstep.subway.applicaion.dto;
+
+public class LineResponse {
+    private Long id;
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
+
+    public LineResponse(Long id, String name, String color, Long upStationId, Long downStationId, int distance) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,20 +1,21 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Station;
+
+import java.util.List;
+
 public class LineResponse {
     private Long id;
     private String name;
     private String color;
-    private Long upStationId;
-    private Long downStationId;
-    private int distance;
+    private List<StationResponse> stations;
 
-    public LineResponse(Long id, String name, String color, Long upStationId, Long downStationId, int distance) {
+
+    public LineResponse(Long id, String name, String color, List<StationResponse> stationResponses) {
         this.id = id;
         this.name = name;
         this.color = color;
-        this.upStationId = upStationId;
-        this.downStationId = downStationId;
-        this.distance = distance;
+        this.stations = stationResponses;
     }
 
     public Long getId() {
@@ -29,15 +30,8 @@ public class LineResponse {
         return color;
     }
 
-    public Long getUpStationId() {
-        return upStationId;
+    public List<StationResponse> getStations() {
+        return stations;
     }
 
-    public Long getDownStationId() {
-        return downStationId;
-    }
-
-    public int getDistance() {
-        return distance;
-    }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineUpdateDto.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineUpdateDto.java
@@ -1,0 +1,28 @@
+package nextstep.subway.applicaion.dto;
+
+public class LineUpdateDto {
+    
+    private String name;
+    private String color;
+
+    public LineUpdateDto(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/StationRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationRequest.java
@@ -3,6 +3,12 @@ package nextstep.subway.applicaion.dto;
 public class StationRequest {
     private String name;
 
+    public StationRequest() {}
+
+    public StationRequest(String name) {
+        this.name = name;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationResponse.java
@@ -1,5 +1,7 @@
 package nextstep.subway.applicaion.dto;
 
+import nextstep.subway.domain.Station;
+
 public class StationResponse {
     private Long id;
     private String name;
@@ -7,6 +9,10 @@ public class StationResponse {
     public StationResponse(Long id, String name) {
         this.id = id;
         this.name = name;
+    }
+
+    public StationResponse(Station station) {
+        this(station.getId(), station.getName());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,5 +1,7 @@
 package nextstep.subway.domain;
 
+import nextstep.subway.applicaion.dto.LineUpdateDto;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -50,5 +52,10 @@ public class Line {
 
     public int getDistance() {
         return distance;
+    }
+
+    public void updateLine(LineUpdateDto dto) {
+        this.name = dto.getName();
+        this.color = dto.getColor();
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,0 +1,54 @@
+package nextstep.subway.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Line {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private int distance;
+
+    public Line() {
+
+    }
+
+    public Line(String name, String color, Long upStationId, Long downStationId, int distance) {
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -1,0 +1,6 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+}

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -3,12 +3,11 @@ package nextstep.subway.ui;
 import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.LineUpdateDto;
+import nextstep.subway.domain.Line;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
@@ -30,6 +29,12 @@ public class LineController {
     @GetMapping(value = "/lines", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<LineResponse>> showLines() {
         return ResponseEntity.ok().body(lineService.findAllLines());
+    }
+
+    @PutMapping("/lines/{id}")
+    public ResponseEntity<Void> updateLines(@PathVariable Long id, @RequestBody LineUpdateDto updateDto) {
+        lineService.updateLine(id, updateDto);
+        return ResponseEntity.ok().build();
     }
 
 

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -3,12 +3,15 @@ package nextstep.subway.ui;
 import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.List;
 
 @RestController
 public class LineController {
@@ -23,6 +26,13 @@ public class LineController {
         LineResponse line = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines" + line.getId())).body(line);
     }
+
+    @GetMapping(value = "/lines", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<LineResponse>> showLines() {
+        return ResponseEntity.ok().body(lineService.findAllLines());
+    }
+
+
 
 
 }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -37,6 +37,13 @@ public class LineController {
         return ResponseEntity.ok().build();
     }
 
+    @DeleteMapping("/lines/{id}")
+    public ResponseEntity<Void> updateLines(@PathVariable Long id) {
+        lineService.deleteLine(id);
+        return ResponseEntity.noContent().build();
+    }
+
+
 
 
 

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -4,7 +4,6 @@ import nextstep.subway.applicaion.LineService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
 import nextstep.subway.applicaion.dto.LineUpdateDto;
-import nextstep.subway.domain.Line;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,0 +1,28 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+public class LineController {
+    private LineService lineService;
+
+    public LineController(LineService lineService) {
+        this.lineService = lineService;
+    }
+
+    @PostMapping("/lines")
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+        LineResponse line = lineService.saveLine(lineRequest);
+        return ResponseEntity.created(URI.create("/lines" + line.getId())).body(line);
+    }
+
+
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -142,8 +142,11 @@ public class LineAcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/stations");
 
+        ExtractableResponse<Response> createResponse = createLine(new Line("1호선", "bg-blue-600", 7L, 8L, 10));
+        Long lineId = createResponse.jsonPath().getLong("id");
 
-
+        ExtractableResponse<Response> updateResponse = updateLine(lineId);
+        assertThat(updateResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
 
     }
 
@@ -171,6 +174,14 @@ public class LineAcceptanceTest {
                 .when().get("/stations")
                 .then().log().all()
                 .extract().jsonPath().getList("name", String.class);
+    }
+
+    // 지하철 노선 업데이트
+    private ExtractableResponse<Response> updateLine(Long id) {
+        return RestAssured.given().log().all()
+                .when().put("/lines/{id}", id)
+                .then().log().all()
+                .extract();
     }
 
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
 
 import java.util.HashMap;
 import java.util.List;
@@ -19,6 +20,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철노선 관련 기능")
+@Sql({"classpath:subway_truncate.sql"})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class LineAcceptanceTest {
     @LocalServerPort
@@ -66,6 +68,9 @@ public class LineAcceptanceTest {
         assertThat(lineName).isEqualTo("신분당선");
         assertThat(lineColor).isEqualTo("bg-red-600");
 
+        List<String> stationNames = getStationNames();
+        System.out.println(stationNames);
+
     }
 
     /**
@@ -76,18 +81,74 @@ public class LineAcceptanceTest {
     @DisplayName("지하철 노선 목록을 조회한다.")
     @Test
     void getLines() {
-        ExtractableResponse<Response> response1 = createLine(new Line("신분당선", "bg-red-600", 1L, 2L, 10));
-        ExtractableResponse<Response> response2 = createLine(new Line("7호선", "bg-brown-600", 1L, 3L, 10));
+
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "강남역");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        params.put("name", "판교역");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        params.put("name", "부평구청역");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        params.put("name", "장암역");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        ExtractableResponse<Response> response1 = createLine(new Line("신분당선", "bg-red-600", 3L, 4L, 10));
+        ExtractableResponse<Response> response2 = createLine(new Line("7호선", "bg-brown-600", 5L, 6L, 10));
 
         List<String> lineNames = RestAssured.given().log().all()
                 .when().get("/lines")
                 .then().log().all()
                 .extract().jsonPath().getList("name", String.class);
 
+        assertThat(lineNames).contains("신분당선", "7호선");
+
+    }
+
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 수정하면
+     * Then 해당 지하철 노선 정보는 수정된다
+     */
+    @DisplayName("지하철 노선을 수정한다.")
+    @Test
+    void updateLines() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "인천역");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        params.put("name", "소요산역");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+
+
+
     }
 
 
-        // 지하철노선 생성
+    // 지하철노선 생성
     private ExtractableResponse<Response> createLine(Line line) {
         Map<String, Object> params = new HashMap<>();
         params.put("name", line.getName());
@@ -103,6 +164,15 @@ public class LineAcceptanceTest {
                 .then().log().all()
                 .extract();
     }
+
+    // 지하철역 이름 조회
+    private List<String> getStationNames() {
+        return RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+    }
+
 
 
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -63,7 +63,7 @@ public class LineAcceptanceTest {
         String lineName = getResponse.jsonPath().getString("[0].name");
         String lineColor = getResponse.jsonPath().getString("[0].color");
 
-        assertThat(lineName).isEqualTo("신분당선");
+        assertThat(lineName).isEqualTo(신분당선);
         assertThat(lineColor).isEqualTo("bg-red-600");
     }
 
@@ -76,42 +76,29 @@ public class LineAcceptanceTest {
     @Test
     void getLines() {
 
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
+        final String 강남역 = "강남역";
+        final String 판교역 = "판교역";
+        final String 부평구청역 = "부평구청역";
+        final String 장암역 = "장암역";
 
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations");
+        final String 신분당선 = "신분당선";
+        final String 칠호선 = "7호선";
 
-        params.put("name", "판교역");
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations");
+        ExtractableResponse<Response> stationCreationResponse1 = StationApiCall.createStation(new StationRequest(강남역));
+        ExtractableResponse<Response> stationCreationResponse2 = StationApiCall.createStation(new StationRequest(판교역));
+        ExtractableResponse<Response> stationCreationResponse3 = StationApiCall.createStation(new StationRequest(부평구청역));
+        ExtractableResponse<Response> stationCreationResponse4 = StationApiCall.createStation(new StationRequest(장암역));
 
-        params.put("name", "부평구청역");
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations");
+        Long 강남역_아이디 = getId(stationCreationResponse1);
+        Long 판교역_아이디 = getId(stationCreationResponse2);
+        Long 부평구청역_아이디 = getId(stationCreationResponse3);
+        Long 장암역_아이디 = getId(stationCreationResponse4);
 
-        params.put("name", "장암역");
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations");
+        LineApiCall.createLine(new LineRequest(신분당선, "bg-red-600", 강남역_아이디, 판교역_아이디, 10));
+        LineApiCall.createLine(new LineRequest(칠호선, "bg-brown-600", 부평구청역_아이디, 장암역_아이디, 10));
 
-        ExtractableResponse<Response> response1 = createLine(new Line("신분당선", "bg-red-600", 3L, 4L, 10));
-        ExtractableResponse<Response> response2 = createLine(new Line("7호선", "bg-brown-600", 5L, 6L, 10));
-
-        List<String> lineNames = RestAssured.given().log().all()
-                .when().get("/lines")
-                .then().log().all()
-                .extract().jsonPath().getList("name", String.class);
-
+        List<String> lineNames = LineApiCall.getLines().jsonPath().getList("name", String.class);
         assertThat(lineNames).contains("신분당선", "7호선");
-
     }
 
     /**
@@ -193,10 +180,6 @@ public class LineAcceptanceTest {
     // 응답객체 id 데이터 조회
     private Long getId(ExtractableResponse<Response> response) {
         return response.jsonPath().getLong("id");
-    }
-
-    private ExtractableResponse<Response> createLine(Line line) {
-        return null;
     }
 
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -51,20 +51,43 @@ public class LineAcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/stations");
 
-        ExtractableResponse<Response> response = createLine(new Line("신분당선", "bg-red-600", 1L, 2L, 10));
+        ExtractableResponse<Response> createResponse = createLine(new Line("신분당선", "bg-red-600", 1L, 2L, 10));
 
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(createResponse.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        ExtractableResponse<Response> getResponse = RestAssured.given().log().all()
+                .when().get("/lines")
+                .then().log().all()
+                .extract();
+
+        String lineName = getResponse.jsonPath().getString("[0].name");
+        String lineColor = getResponse.jsonPath().getString("[0].color");
+
+        assertThat(lineName).isEqualTo("신분당선");
+        assertThat(lineColor).isEqualTo("bg-red-600");
+
+    }
+
+    /**
+     * Given 2개의 지하철 노선을 생성하고
+     * When 지하철 노선 목록을 조회하면
+     * Then 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다.
+     */
+    @DisplayName("지하철 노선 목록을 조회한다.")
+    @Test
+    void getLines() {
+        ExtractableResponse<Response> response1 = createLine(new Line("신분당선", "bg-red-600", 1L, 2L, 10));
+        ExtractableResponse<Response> response2 = createLine(new Line("7호선", "bg-brown-600", 1L, 3L, 10));
 
         List<String> lineNames = RestAssured.given().log().all()
                 .when().get("/lines")
                 .then().log().all()
                 .extract().jsonPath().getList("name", String.class);
 
-        assertThat(lineNames.contains("신분당선")).isEqualTo(true);
     }
 
 
-    // 지하철노선 생성
+        // 지하철노선 생성
     private ExtractableResponse<Response> createLine(Line line) {
         Map<String, Object> params = new HashMap<>();
         params.put("name", line.getName());

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -39,12 +39,12 @@ public class LineAcceptanceTest {
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
-        List<String> lineNames = RestAssured.given().log().all()
-                .when().get("/lines")
-                .then().log().all()
-                .extract().jsonPath().getList("name", String.class);
-
-        assertThat(lineNames.contains("1호선")).isEqualTo(true);
+//        List<String> lineNames = RestAssured.given().log().all()
+//                .when().get("/lines")
+//                .then().log().all()
+//                .extract().jsonPath().getList("name", String.class);
+//
+//        assertThat(lineNames.contains("1호선")).isEqualTo(true);
     }
 
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -38,29 +38,29 @@ public class LineAcceptanceTest {
     void createSubwayLine() {
 
         Map<String, String> params = new HashMap<>();
-        params.put("name", "구로역");
+        params.put("name", "강남역");
 
         RestAssured.given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/stations");
 
-        params.put("name", "부천역");
+        params.put("name", "광교역");
         RestAssured.given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/stations");
 
-        ExtractableResponse<Response> response = createLine(new Line("1호선", "bg-blue-600", 1L, 2L, 10));
+        ExtractableResponse<Response> response = createLine(new Line("신분당선", "bg-red-600", 1L, 2L, 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
-//        List<String> lineNames = RestAssured.given().log().all()
-//                .when().get("/lines")
-//                .then().log().all()
-//                .extract().jsonPath().getList("name", String.class);
-//
-//        assertThat(lineNames.contains("1호선")).isEqualTo(true);
+        List<String> lineNames = RestAssured.given().log().all()
+                .when().get("/lines")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+
+        assertThat(lineNames.contains("신분당선")).isEqualTo(true);
     }
 
 

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.domain.Line;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,7 +36,22 @@ public class LineAcceptanceTest {
     @DisplayName("지하철 노선을 생성한다.")
     @Test
     void createSubwayLine() {
-        ExtractableResponse<Response> response = createLine("1호선");
+
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "구로역");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        params.put("name", "부천역");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        ExtractableResponse<Response> response = createLine(new Line("1호선", "bg-blue-600", 1L, 2L, 10));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
@@ -49,9 +65,13 @@ public class LineAcceptanceTest {
 
 
     // 지하철노선 생성
-    private ExtractableResponse<Response> createLine(String LineName) {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", LineName);
+    private ExtractableResponse<Response> createLine(Line line) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("name", line.getName());
+        params.put("color", line.getColor());
+        params.put("upStationId", line.getUpStationId());
+        params.put("downStationId", line.getDownStationId());
+        params.put("distance", line.getDistance());
 
         return RestAssured.given().log().all()
                 .body(params)

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,0 +1,66 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("지하철노선 관련 기능")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LineAcceptanceTest {
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    /**
+     * When 지하철 노선을 생성하면
+     * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
+     */
+    @DisplayName("지하철 노선을 생성한다.")
+    @Test
+    void createSubwayLine() {
+        ExtractableResponse<Response> response = createLine("1호선");
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        List<String> lineNames = RestAssured.given().log().all()
+                .when().get("/lines")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+
+        assertThat(lineNames.contains("1호선")).isEqualTo(true);
+    }
+
+
+    // 지하철노선 생성
+    private ExtractableResponse<Response> createLine(String LineName) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", LineName);
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+
+
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -162,6 +162,41 @@ public class LineAcceptanceTest {
 
     }
 
+    /**
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 삭제하면
+     * Then 해당 지하철 노선 정보는 삭제된다
+     */
+    @DisplayName("지하철 노선을 삭제한다.")
+    @Test
+    void deleteLines() {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", "수원역");
+
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        params.put("name", "정자역");
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations");
+
+        ExtractableResponse<Response> createResponse = createLine(new Line("분당선", "bg-yellow-600", 1L, 2L, 10));
+
+        Long lineId = createResponse.jsonPath().getLong("id");
+
+        ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()
+                .when().delete("/lines/{id}", lineId)
+                .then().log().all()
+                .extract();
+
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
+    }
+
 
     // 지하철노선 생성
     private ExtractableResponse<Response> createLine(Line line) {

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -5,7 +5,6 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
@@ -36,7 +35,6 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 생성한다.")
     @Test
-    @Order(1)
     void createStation() {
         final String GANG_NAM = "강남역";
 
@@ -58,7 +56,6 @@ public class StationAcceptanceTest {
     // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
     @DisplayName("지하철역을 조회한다.")
     @Test
-    @Order(2)
     void getStations() {
         final String SIN_DO_RIM = "신도림역";
         final String GURO_DIGITAL_COMPLEX = "구로디지털단지역";
@@ -81,7 +78,6 @@ public class StationAcceptanceTest {
     // TODO: 지하철역 제거 인수 테스트 메서드 생성
     @DisplayName("지하철역을 제거한다.")
     @Test
-    @Order(3)
     void deleteStation() {
         final String BU_CHEON = "부천역";
 

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -53,7 +53,6 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
     @DisplayName("지하철역을 조회한다.")
     @Test
     void getStations() {
@@ -75,7 +74,6 @@ public class StationAcceptanceTest {
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
     @DisplayName("지하철역을 제거한다.")
     @Test
     void deleteStation() {
@@ -91,8 +89,29 @@ public class StationAcceptanceTest {
         assertThat(getStationNames()).doesNotContain(BU_CHEON);
     }
 
+    /**
+     * When 지하철 노선을 생성하면
+     * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
+     */
+    @DisplayName("지하철 노선을 생성한다.")
+    @Test
+    void createSubwayLine() {
+        ExtractableResponse<Response> response = createLine("1호선");
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        List<String> lineNames = RestAssured.given().log().all()
+                .when().get("/lines")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+
+        assertThat(lineNames.contains("1호선")).isEqualTo(true);
+
+    }
+
+
     // 지하철역 이름 조회
-    public List<String> getStationNames() {
+    private List<String> getStationNames() {
         return RestAssured.given().log().all()
                 .when().get("/stations")
                 .then().log().all()
@@ -100,7 +119,7 @@ public class StationAcceptanceTest {
     }
 
     // 지하철역 생성
-    public ExtractableResponse<Response> createStation(String stationName) {
+    private ExtractableResponse<Response> createStation(String stationName) {
         Map<String, String> params = new HashMap<>();
         params.put("name", stationName);
 
@@ -112,8 +131,22 @@ public class StationAcceptanceTest {
                 .extract();
     }
 
+    // 지하철노선 생성
+    private ExtractableResponse<Response> createLine(String LineName) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", LineName);
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+
     // 지하철역 삭제
-    public ExtractableResponse<Response> deleteStation(Integer id) {
+    private ExtractableResponse<Response> deleteStation(Integer id) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().delete("/stations/" + id)

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -89,26 +89,6 @@ public class StationAcceptanceTest {
         assertThat(getStationNames()).doesNotContain(BU_CHEON);
     }
 
-    /**
-     * When 지하철 노선을 생성하면
-     * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
-     */
-    @DisplayName("지하철 노선을 생성한다.")
-    @Test
-    void createSubwayLine() {
-        ExtractableResponse<Response> response = createLine("1호선");
-
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-
-        List<String> lineNames = RestAssured.given().log().all()
-                .when().get("/lines")
-                .then().log().all()
-                .extract().jsonPath().getList("name", String.class);
-
-        assertThat(lineNames.contains("1호선")).isEqualTo(true);
-
-    }
-
 
     // 지하철역 이름 조회
     private List<String> getStationNames() {
@@ -130,20 +110,6 @@ public class StationAcceptanceTest {
                 .then().log().all()
                 .extract();
     }
-
-    // 지하철노선 생성
-    private ExtractableResponse<Response> createLine(String LineName) {
-        Map<String, String> params = new HashMap<>();
-        params.put("name", LineName);
-
-        return RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all()
-                .extract();
-    }
-
 
     // 지하철역 삭제
     private ExtractableResponse<Response> deleteStation(Integer id) {

--- a/src/test/java/nextstep/subway/api/LineApiCall.java
+++ b/src/test/java/nextstep/subway/api/LineApiCall.java
@@ -1,0 +1,30 @@
+package nextstep.subway.api;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.applicaion.dto.LineRequest;
+import org.springframework.http.MediaType;
+
+public class LineApiCall {
+
+    // 지하철노선 생성
+    public static ExtractableResponse<Response> createLine(LineRequest request) {
+        return RestAssured.given().log().all()
+                .body(request)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all()
+                .extract();
+
+    }
+
+    // 지하철 노선 조회
+    public static ExtractableResponse<Response> getLines() {
+        return RestAssured.given().log().all()
+                .when().get("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+}

--- a/src/test/java/nextstep/subway/api/LineApiCall.java
+++ b/src/test/java/nextstep/subway/api/LineApiCall.java
@@ -4,11 +4,12 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineUpdateDto;
 import org.springframework.http.MediaType;
 
 public class LineApiCall {
 
-    // 지하철노선 생성
+    // 지하철노선 생성 요청
     public static ExtractableResponse<Response> createLine(LineRequest request) {
         return RestAssured.given().log().all()
                 .body(request)
@@ -19,12 +20,31 @@ public class LineApiCall {
 
     }
 
-    // 지하철 노선 조회
+    // 지하철노선 조회 요청
     public static ExtractableResponse<Response> getLines() {
         return RestAssured.given().log().all()
                 .when().get("/lines")
                 .then().log().all()
                 .extract();
     }
+
+    // 지하철노선 수정 요청
+    public static ExtractableResponse<Response> updateLine(Long id, LineUpdateDto updateDto) {
+        return RestAssured.given().log().all()
+                .body(updateDto)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put("/lines/{id}", id)
+                .then().log().all()
+                .extract();
+    }
+
+    // 지하철노선 삭제 요청
+    public static ExtractableResponse<Response> deleteLine(Long id) {
+        return RestAssured.given().log().all()
+                .when().delete("/lines/{id}", id)
+                .then().log().all()
+                .extract();
+    }
+
 
 }

--- a/src/test/java/nextstep/subway/api/StationApiCall.java
+++ b/src/test/java/nextstep/subway/api/StationApiCall.java
@@ -19,9 +19,4 @@ public class StationApiCall {
                 .extract();
     }
 
-
-
-
-
-
 }

--- a/src/test/java/nextstep/subway/api/StationApiCall.java
+++ b/src/test/java/nextstep/subway/api/StationApiCall.java
@@ -1,0 +1,27 @@
+package nextstep.subway.api;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.StationRequest;
+import org.springframework.http.MediaType;
+
+public class StationApiCall {
+
+    // 지하철역 생성 요청
+    public static ExtractableResponse<Response> createStation(StationRequest request) {
+        return RestAssured.given().log().all()
+                .body(request)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+
+
+
+
+
+}

--- a/src/test/resources/subway_truncate.sql
+++ b/src/test/resources/subway_truncate.sql
@@ -1,0 +1,2 @@
+truncate table station;
+truncate table line;


### PR DESCRIPTION
안녕하세요 현성님, 제가 과제를 너무 늦게 제출하네요 ㅜㅜ 
Step2 지하철노선기능 리뷰 요청 드립니다!

자동 증가 칼럼(id) 관련하여 질문이 있습니다.

지하철 노선 인수테스트 메서드 동작 시마다 truncate sql문을 수행하여 (truncate table station)
이전 메서드에서 생성했던 지하철역 정보는 다 제거되도록 했습니다.

그래서 다음 메서드 넘어가서 지하철역을 다시 생성하면 id값이 초기화되어
id가 1인 지하철역이 생성될 줄 알았는데, 이전 메서드에서 마지막으로 생성했던 지하철역 id의 다음값으로 세팅이 되더라구요.

이게 테이블의 id컬럼 시퀀스까지 초기화하고 싶었다면
제가 추가적으로 시퀀스를 초기화하는 sql문까지 따로 적어줘야 했던 걸까요?

감사합니다!

