### PR TITLE
🚀 3단계 - 지하철 구간 관리

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,95 @@ table이 늘어 날때 마다 sql을 작성해 줘야 한다.
 ![datacleanup](./docs/step2/datacleanup.png)
 
 그래서 Entity를 모두 조회 후, truncate를 하는 방식으로 수정 하였다.
+
+
+## step3 
+
+## 코멘트 생각하기
+
+- [x] 테스트 설정 관련 리팩토링 하기
+
+```java
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptionceTest {
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+        databaseCleanup.execute();
+    }
+
+}
+```
+
+만들어 사용.
+
+- [x] 인수 테스트할때는 깔끔하게 작성하기 위해 필요 값은 위쪽에 만들어두기
+
+```java
+@DisplayName("구간 등록 기능 테스트")
+@Test
+void createSectionTest() {
+        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);
+
+        ExtractableResponse<Response> 지하철구간_생성 = 지하철_구간_생성(1L, 2L, 3L, 4);
+        assertThat(지하철구간_생성.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        ExtractableResponse<Response> response = 지하철_노선_조회(1L);
+        하행선값_검증(response, "선릉역");
+}
+```
+
+- [x] AccessLevel 설정하여 만들기
+
+```java
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class Section {
+    
+}
+```
+
+- [x] 도메인쪽에 Applcaiton Layer 참조하지 않고 사용하기
+
+dto 에서 만들어 사용함.
+```java
+public StationLine toEntity() {
+        return StationLine.builder()
+            .name(name)
+            .color(color)
+            .upStationId(upStationId)
+            .downStationId(downStationId)
+            .distance(distance)
+            .build();
+    }
+```
+
+### 기능 정리
+
+- [x] 구간 등록 기능추가
+  - [x] (예외) 새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.
+  - [x] (예외) 새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.
+
+- [x] 구간 삭제 기능 추가
+  - [x] (예외) 지하철 노선에 등록된 역(하행 종점역)만 제거할 수 있다. 즉, 마지막 구간만 제거할 수 있다.
+  - [x] (예외) 지하철 노선에 상행 종점역과 하행 종점역만 있는 경우(구간이 1개인 경우) 역을 삭제할 수 없다.
+
+### 테스트 케이스 추가
+
+- [x] 구간 등록 테스트 작성
+- [x] 구간 하행 종점역만 등록 가능하도록 예외 테스트 작성
+- [x] 중복된 역은 추가 될수 없다.
+
+
+- [x] 구간 삭제
+- [x] 마지막 구간만 제거 되도록 테스트 코드 작성
+- [x] (구간이 1개인 경우) 역을 삭제할 수 없다 테스트 코드 작성

--- a/src/main/java/nextstep/subway/applicaion/StationLineService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationLineService.java
@@ -1,10 +1,16 @@
 package nextstep.subway.applicaion;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.dto.SectionResponse;
 import nextstep.subway.applicaion.dto.StationLineRequest;
 import nextstep.subway.applicaion.dto.StationLineResponse;
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.constant.Message;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.SectionRepository;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.StationLine;
 import nextstep.subway.domain.StationLineRepository;
@@ -18,20 +24,25 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class StationLineService {
     private final StationLineRepository stationLineRepository;
     private final StationRepository stationRepository;
+    private final SectionRepository sectionRepository;
 
     @Transactional
     public StationLineResponse createStationLine(StationLineRequest stationLineRequest) {
-        List<StationResponse> stations = stationRepository.findAllById(List.of(
-                stationLineRequest.getUpStationId(),
-                stationLineRequest.getDownStationId()))
-                .stream()
-                .map(station -> StationResponse.of(station))
-                .collect(Collectors.toList());
+        List<StationResponse> stations = findByUpStationAndDownStation(stationLineRequest.getUpStationId(),
+            stationLineRequest.getDownStationId());
 
-        StationLine stationLine = stationLineRepository.save(StationLine.of(stationLineRequest));
+        StationLine stationLine = stationLineRepository.save(stationLineRequest.toEntity());
+
+        sectionRepository.save(Section.builder()
+                .stationLine(stationLine)
+                .upStation(findByStationById(stationLineRequest.getUpStationId()))
+                .downStation(findByStationById(stationLineRequest.getDownStationId()))
+                .distance(stationLineRequest.getDistance())
+                .build());
 
         return StationLineResponse.of(stationLine, stations);
     }
@@ -39,13 +50,15 @@ public class StationLineService {
     public List<StationLineResponse> findAllStationLine() {
         return stationLineRepository.findAll()
                 .stream()
-                .map(stationLine -> StationLineResponse.of(stationLine, findByUpStationAndDownStation(stationLine)))
+                .map(stationLine -> StationLineResponse.of(stationLine,
+                    findByUpStationAndDownStation(stationLine.getUpStationId(),
+                        stationLine.getDownStationId())))
                 .collect(Collectors.toList());
     }
 
     public StationLineResponse findByStationLineId(Long stationLineId) {
         StationLine stationLine = findByStationLine(stationLineId);
-        return StationLineResponse.of(stationLine, findByUpStationAndDownStation(stationLine));
+        return StationLineResponse.of(stationLine, findByUpStationAndDownStation(stationLine.getUpStationId(), stationLine.getDownStationId()));
     }
 
     @Transactional
@@ -63,10 +76,31 @@ public class StationLineService {
         return stationLineRepository.findById(stationLineId).get();
     }
 
-    private List<StationResponse> findByUpStationAndDownStation(StationLine stationLine) {
-        return stationRepository.findAllById(List.of(
-                stationLine.getUpStationId(),
-                stationLine.getDownStationId()))
+    @Transactional
+    public SectionResponse createSection(Long id, SectionRequest sectionRequest) {
+        StationLine stationLine = findByStationLine(id);
+
+        Station upStation = findByStationById(sectionRequest.getUpStationId());
+        Station downStation = findByStationById(sectionRequest.getDownStationId());
+
+        Section section = stationLine.addSection(upStation, downStation, sectionRequest.getDistance());
+        return SectionResponse.of(sectionRepository.save(section));
+    }
+
+    @Transactional
+    public Section deleteSection(Long id, Long stationId) {
+        StationLine stationLine = findByStationLine(id);
+
+        return stationLine.removeSection(stationId);
+    }
+
+    private Station findByStationById(Long stationId) {
+        return stationRepository.findById(stationId)
+            .orElseThrow(() -> new IllegalArgumentException(Message.NOT_FOUND_STATION.getValue()));
+    }
+
+    private List<StationResponse> findByUpStationAndDownStation(Long upStationLineId, Long downStationLineId) {
+        return stationRepository.findAllById(List.of(upStationLineId, downStationLineId))
                 .stream()
                 .map(station -> StationResponse.of(station))
                 .collect(Collectors.toList());

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -1,5 +1,6 @@
 package nextstep.subway.applicaion;
 
+import lombok.RequiredArgsConstructor;
 import nextstep.subway.applicaion.dto.StationRequest;
 import nextstep.subway.applicaion.dto.StationResponse;
 import nextstep.subway.domain.Station;
@@ -12,12 +13,9 @@ import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class StationService {
-    private StationRepository stationRepository;
-
-    public StationService(StationRepository stationRepository) {
-        this.stationRepository = stationRepository;
-    }
+    private final StationRepository stationRepository;
 
     @Transactional
     public StationResponse saveStation(StationRequest stationRequest) {

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -1,0 +1,23 @@
+package nextstep.subway.applicaion.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nextstep.subway.domain.Section;
+
+@Getter
+@NoArgsConstructor
+public class SectionRequest {
+
+    private Long downStationId;
+    private Long upStationId;
+    private Integer distance;
+
+    @Builder
+    public SectionRequest(Long upStationId, Long downStationId, Integer distance) {
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
@@ -1,0 +1,33 @@
+package nextstep.subway.applicaion.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nextstep.subway.domain.Section;
+
+@Getter
+@NoArgsConstructor
+public class SectionResponse {
+    private Long id;
+    private Long upStationId;
+    private Long downStationId;
+    private Integer distance;
+
+    @Builder
+    public SectionResponse(Long id, Long upStationId, Long downStationId, Integer distance) {
+        this.id = id;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
+    public static SectionResponse of(Section section) {
+        return SectionResponse.builder()
+            .id(section.getId())
+            .upStationId(section.getUpStation().getId())
+            .downStationId(section.getDownStation().getId())
+            .distance(section.getDistance())
+            .build();
+    }
+
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/StationLineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationLineRequest.java
@@ -1,6 +1,7 @@
 package nextstep.subway.applicaion.dto;
 
 import lombok.*;
+import nextstep.subway.domain.StationLine;
 
 @Getter
 @NoArgsConstructor
@@ -19,4 +20,15 @@ public class StationLineRequest {
         this.downStationId = downStationId;
         this.distance = distance;
     }
+
+    public StationLine toEntity() {
+        return StationLine.builder()
+            .name(name)
+            .color(color)
+            .upStationId(upStationId)
+            .downStationId(downStationId)
+            .distance(distance)
+            .build();
+    }
+
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/StationRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/StationRequest.java
@@ -1,9 +1,8 @@
 package nextstep.subway.applicaion.dto;
 
+import lombok.Getter;
+
+@Getter
 public class StationRequest {
     private String name;
-
-    public String getName() {
-        return name;
-    }
 }

--- a/src/main/java/nextstep/subway/constant/Message.java
+++ b/src/main/java/nextstep/subway/constant/Message.java
@@ -1,0 +1,20 @@
+package nextstep.subway.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum Message {
+
+    NOT_FOUND_STATION("해당 역을 찾을 수 없습니다."),
+
+    ONLY_ADD_DOWNSTATION("하행선만 등록 가능합니다."),
+    IS_EXIST_STATION("이미 등록된 역입니다."),
+
+    ONLY_DELETE_DOWNSTAION("하행선만 삭제 가능합니다."),
+    ONE_COUNT_SECTIONLIST("구간이 1개여서 삭제할 수 없습니다.");
+
+    private String value;
+
+}

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,0 +1,49 @@
+package nextstep.subway.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class Section {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Integer distance;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private StationLine stationLine;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Station downStation;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Station upStation;
+
+    @Builder
+    public Section(StationLine stationLine, Station upStation, Station downStation, Integer distance) {
+        this.stationLine = stationLine;
+        this.upStation = upStation;
+        this.downStation = downStation;
+        this.distance = distance;
+    }
+
+    public void updateStationLine(StationLine stationLine) {
+        this.stationLine = stationLine;
+    }
+
+}

--- a/src/main/java/nextstep/subway/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/domain/SectionRepository.java
@@ -1,0 +1,7 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SectionRepository extends JpaRepository<Section, Long> {
+
+}

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -1,0 +1,71 @@
+package nextstep.subway.domain;
+
+import java.util.LinkedList;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import javax.persistence.OrderBy;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import nextstep.subway.constant.Message;
+import nextstep.subway.exception.IllegalUpdatingStateException;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sections {
+
+    @OneToMany(mappedBy = "stationLine",
+        fetch = FetchType.LAZY,
+        cascade = {CascadeType.PERSIST, CascadeType.MERGE} ,
+        orphanRemoval = true)
+    @OrderBy(value = "id")
+    private List<Section> sections = new LinkedList<>();
+
+
+    public Section add(Section section) {
+        validateAddSection(section);
+
+        sections.add(section);
+        return section;
+    }
+
+    public void validateAddSection(Section newSection) {
+        validateDownSection(newSection);
+        validateDistinctSection(newSection);
+    }
+
+    public void validateDownSection(Section newSection) {
+        Section lastSection = getLastSection();
+
+        if(!lastSection.getDownStation().getId().equals(newSection.getUpStation().getId())) {
+            throw new IllegalUpdatingStateException(Message.ONLY_ADD_DOWNSTATION.getValue());
+        }
+    }
+
+    public void validateDistinctSection(Section newSection) {
+        sections.stream()
+            .filter(station -> station.getUpStation().equals(newSection.getDownStation()))
+            .findFirst()
+            .ifPresent(station -> { throw new IllegalUpdatingStateException( Message.IS_EXIST_STATION.getValue()); });
+    }
+
+    public Section remove(Long stationId) {
+        validateRemove();
+        return sections.remove(sections.size() - 1);
+    }
+
+    public void validateRemove() {
+        if(sections.size() == 1) {
+            throw new IllegalUpdatingStateException( Message.ONE_COUNT_SECTIONLIST.getValue());
+        }
+    }
+
+    public Section getLastSection() {
+        return sections.get(sections.size()-1);
+    }
+
+}

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -4,26 +4,23 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private String name;
 
-    public Station() {
-    }
-
+    @Builder
     public Station(String name) {
         this.name = name;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public String getName() {
-        return name;
-    }
 }

--- a/src/main/java/nextstep/subway/domain/StationLine.java
+++ b/src/main/java/nextstep/subway/domain/StationLine.java
@@ -1,5 +1,6 @@
 package nextstep.subway.domain;
 
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,10 +9,12 @@ import nextstep.subway.applicaion.dto.StationRequest;
 
 import javax.persistence.*;
 import java.util.List;
+import nextstep.subway.constant.Message;
+import nextstep.subway.exception.IllegalUpdatingStateException;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StationLine {
 
     @Id
@@ -28,27 +31,66 @@ public class StationLine {
 
     private Integer distance;
 
+    @Embedded
+    private Sections sections = new Sections();
+
     @Builder
-    public StationLine(String name, String color, Long upStationId, Long downStationId, Integer distance) {
+    public StationLine(String name, String color, Long upStationId, Long downStationId, Integer distance, Sections sections) {
         this.name = name;
         this.color = color;
         this.upStationId = upStationId;
         this.downStationId = downStationId;
         this.distance = distance;
-    }
-
-    public static StationLine of(StationLineRequest stationLineRequest) {
-        return StationLine.builder()
-                .name(stationLineRequest.getName())
-                .color(stationLineRequest.getColor())
-                .upStationId(stationLineRequest.getUpStationId())
-                .downStationId(stationLineRequest.getDownStationId())
-                .build();
+        this.sections = sections;
     }
 
     public void update(String name, String color) {
         this.name = name;
         this.color = color;
+    }
+
+    public Section addSection(Station upStation, Station downStation, Integer distance) {
+        Section section = Section.builder()
+            .upStation(upStation)
+            .downStation(downStation)
+            .distance(distance)
+            .build();
+
+        updateDownStation(downStation);
+        plusDistance(distance);
+        section.updateStationLine(this);
+
+        return sections.add(section);
+    }
+
+    public void updateDownStation(Station downStation) {
+        this.downStationId = downStation.getId();
+    }
+
+    public void plusDistance(Integer distance) {
+        this.distance += distance;
+    }
+
+    public void minusDistance(Integer distance) {
+        this.distance -= distance;
+    }
+
+    public Section removeSection(Long stationId) {
+        validateDownStation(stationId);
+
+        Section section = sections.remove(stationId);
+        Section lastSection = sections.getLastSection();
+
+        updateDownStation(lastSection.getDownStation());
+        minusDistance(section.getDistance());
+
+        return section;
+    }
+
+    public void validateDownStation(Long stationId) {
+        if(!downStationId.equals(stationId)) {
+            throw new IllegalUpdatingStateException(Message.ONLY_DELETE_DOWNSTAION.getValue());
+        }
     }
 
 }

--- a/src/main/java/nextstep/subway/exception/GlobalExceptionAdvice.java
+++ b/src/main/java/nextstep/subway/exception/GlobalExceptionAdvice.java
@@ -1,0 +1,18 @@
+package nextstep.subway.exception;
+
+import nextstep.subway.exception.dto.CommonExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionAdvice {
+
+    @ExceptionHandler(value = IllegalUpdatingStateException.class)
+    public ResponseEntity<CommonExceptionResponse> handleUpdatingStateException(Exception e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+            .body(CommonExceptionResponse.builder().exception(e).build());
+    }
+
+}

--- a/src/main/java/nextstep/subway/exception/IllegalUpdatingStateException.java
+++ b/src/main/java/nextstep/subway/exception/IllegalUpdatingStateException.java
@@ -1,0 +1,8 @@
+package nextstep.subway.exception;
+
+public class IllegalUpdatingStateException extends RuntimeException {
+
+    public IllegalUpdatingStateException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/exception/dto/CommonExceptionResponse.java
+++ b/src/main/java/nextstep/subway/exception/dto/CommonExceptionResponse.java
@@ -1,0 +1,15 @@
+package nextstep.subway.exception.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommonExceptionResponse {
+    private String message;
+
+    @Builder
+    public CommonExceptionResponse(Exception exception) {
+        this.message = exception.getLocalizedMessage();
+    }
+
+}

--- a/src/main/java/nextstep/subway/ui/SectionController.java
+++ b/src/main/java/nextstep/subway/ui/SectionController.java
@@ -1,0 +1,39 @@
+package nextstep.subway.ui;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import nextstep.subway.applicaion.StationLineService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.dto.SectionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/lines/{lineId}/sections")
+public class SectionController {
+
+    private final StationLineService stationLineService;
+
+    @PostMapping
+    public ResponseEntity<SectionResponse> createSection(@RequestBody SectionRequest sectionRequest,
+                                                         @PathVariable Long lineId) {
+        SectionResponse sectionResponse = stationLineService.createSection(lineId, sectionRequest);
+        return ResponseEntity.created(URI.create(String.format("/lines/%s/sections", sectionResponse.getId())))
+            .body(sectionResponse);
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteSection(@RequestParam Long stationId,
+                                              @PathVariable Long lineId) {
+        stationLineService.deleteSection(lineId, stationId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/AcceptionceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AcceptionceTest.java
@@ -1,0 +1,25 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import nextstep.subway.utils.DatabaseCleanup;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptionceTest {
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+        databaseCleanup.execute();
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,0 +1,115 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import nextstep.subway.applicaion.dto.StationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static nextstep.subway.api.ApiCall.*;
+
+@DisplayName("지하철 관리")
+public class SectionAcceptanceTest extends AcceptionceTest{
+
+    @BeforeEach
+    public void createMockData() {
+        지하철역_생성("강남역");
+        지하철역_생성("역삼역");
+        지하철역_생성("선릉역");
+    }
+
+    /**
+     * when 지하철 노선 생성
+     * when 지하철 노선 추가
+     * then 지하철 구간 등록후, 하행선 검증.
+     *
+     */
+    @DisplayName("구간 등록 기능 테스트")
+    @Test
+    void createSectionTest() {
+        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);
+
+        ExtractableResponse<Response> 지하철구간_생성 = 지하철_구간_생성(1L, 2L, 3L, 4);
+        assertThat(지하철구간_생성.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        ExtractableResponse<Response> response = 지하철_노선_조회(1L);
+        하행선값_검증(response, "선릉역");
+    }
+
+    @DisplayName("새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.")
+    @Test
+    void exception_notEqualsAddDownStationId() {
+        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);
+
+        ExtractableResponse<Response> exceptionResponse = 지하철_구간_생성(1L, 1L, 2L, 4);
+        assertThat(exceptionResponse.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(exceptionResponse.jsonPath().getString("message")).isEqualTo("하행선만 등록 가능합니다.");
+    }
+
+    @DisplayName("새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.")
+    @Test
+    void exception_isExstsStation() {
+        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);
+
+        ExtractableResponse<Response> exceptionResponse = 지하철_구간_생성(1L, 2L, 1L, 4);
+        assertThat(exceptionResponse.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(exceptionResponse.jsonPath().getString("message")).isEqualTo("이미 등록된 역입니다.");
+    }
+
+
+    /**
+     * when 지하철 노선 추가
+     * when 지하철 구간 삭제
+     * then 지하철 조회후, 하생선 체크
+     *
+     */
+    @DisplayName("구간 제거 기능 테스트")
+    @Test
+    void deleteSectionTest() {
+        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);
+
+        ExtractableResponse<Response> createSection = 지하철_구간_생성(1L, 2L, 3L, 4);
+        assertThat(createSection.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        ExtractableResponse<Response> deleteSection = 지하철_구간_삭제(1L, 3L);
+        assertThat(deleteSection.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
+        ExtractableResponse<Response> response = 지하철_노선_조회(1L);
+        하행선값_검증(response, "역삼역");
+    }
+
+    @DisplayName("마지막 구간만 제거할 수 있다.")
+    @Test
+    void exception_onlyDeleteDownSection() {
+        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);
+
+        ExtractableResponse<Response> createSection = 지하철_구간_생성(1L, 2L, 3L, 4);
+        assertThat(createSection.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        ExtractableResponse<Response> exceptionResponse = 지하철_구간_삭제(1L, 2L);
+        assertThat(exceptionResponse.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(exceptionResponse.jsonPath().getString("message")).isEqualTo("하행선만 삭제 가능합니다.");
+    }
+
+    @DisplayName("(구간이 1개인 경우) 역을 삭제할 수 없다.")
+    @Test
+    void exception_notDeleteSectionOne() {
+        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);
+
+        ExtractableResponse<Response> exceptionResponse = 지하철_구간_삭제(1L, 2L);
+        assertThat(exceptionResponse.statusCode()).isEqualTo(HttpStatus.CONFLICT.value());
+        assertThat(exceptionResponse.jsonPath().getString("message")).isEqualTo("구간이 1개여서 삭제할 수 없습니다.");
+    }
+
+    private void 하행선값_검증(ExtractableResponse<Response> response, String name) {
+        List<StationResponse> stationList = response.jsonPath().getList("stations", StationResponse.class);
+        String downStationName = stationList.get(stationList.size()-1).getName();
+
+        assertThat(downStationName).isEqualTo(name);
+    }
+
+}

--- a/src/test/java/nextstep/subway/api/ApiCall.java
+++ b/src/test/java/nextstep/subway/api/ApiCall.java
@@ -1,0 +1,150 @@
+package nextstep.subway.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import nextstep.subway.applicaion.dto.StationLineRequest;
+import nextstep.subway.applicaion.dto.StationResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+public class ApiCall {
+
+    public static ExtractableResponse<Response> 지하철_구간_생성(Long id, Long upStationId, Long downStationId, Integer distance) {
+        Map<String, Object> params = new HashMap();
+        params.put("upStationId", upStationId);
+        params.put("downStationId", downStationId);
+        params.put("distance", distance);
+
+        return RestAssured
+            .given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/lines/{id}/sections", id)
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_구간_삭제(Long id, Long stationId) {
+        return RestAssured
+            .given().log().all()
+            .queryParam("stationId", stationId)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().delete("/lines/{id}/sections", id)
+            .then().log().all()
+            .extract();
+    }
+
+    public static Long 지하철역_생성(String name) {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .body(Collections.singletonMap("name", name))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/stations")
+            .then().log().all()
+            .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        return response.jsonPath().getLong("id");
+    }
+
+    public static List<String> 지하철역_목록_조회() {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .when().get("/stations")
+            .then().log().all()
+            .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        return response.jsonPath().getList("name");
+    }
+
+    public static void 지하철역_삭제(Long id) {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .when().delete("/stations/{id}", id)
+            .then().log().all()
+            .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static void 지하철_노선_삭제(Long stationLineId) {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().delete("/lines/{id}", stationLineId)
+            .then().log().all()
+            .extract();
+
+        validateHttpStatus(response, HttpStatus.NO_CONTENT);
+    }
+
+    public static Long 지하철_노선_생성(String lineName,
+        String color,
+        Long upStationId,
+        Long downStationId,
+        Integer distance) {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .body(StationLineRequest.builder()
+                .name(lineName)
+                .color(color)
+                .upStationId(upStationId)
+                .downStationId(downStationId)
+                .distance(distance)
+                .build())
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/lines")
+            .then().log().all()
+            .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        return response.jsonPath().getLong("id");
+    }
+
+    public static void 지하철_노선_업데이트(Long stationLineId, StationLineRequest stationLineRequest) {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .body(stationLineRequest)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().put("/lines/{id}", stationLineId)
+            .then().log().all()
+            .extract();
+
+        validateHttpStatus(response, HttpStatus.OK);
+    }
+
+    public static List<String> 지하철_노선_목록_조회() {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .when().get("/lines")
+            .then().log().all()
+            .extract();
+
+        validateHttpStatus(response, HttpStatus.OK);
+        return response.jsonPath().getList("name");
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회(Long stationLineId) {
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .when().get("/lines/{id}", stationLineId)
+            .then().log().all()
+            .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        return response;
+    }
+
+}


### PR DESCRIPTION
## step3 

## 코멘트 생각하기

- [x] 테스트 설정 관련 리팩토링 하기

```java
@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
public class AcceptionceTest {

    @Autowired
    private DatabaseCleanup databaseCleanup;

    @LocalServerPort
    int port;

    @BeforeEach
    public void setUp() {
        RestAssured.port = port;
        databaseCleanup.execute();
    }

}
```

만들어 사용.

- [x] 인수 테스트할때는 깔끔하게 작성하기 위해 필요 값은 위쪽에 만들어두기

```java
@DisplayName("구간 등록 기능 테스트")
@Test
void createSectionTest() {
        지하철_노선_생성("2호선", "bg-green-600", 1L, 2L , 6);

        ExtractableResponse<Response> 지하철구간_생성 = 지하철_구간_생성(1L, 2L, 3L, 4);
        assertThat(지하철구간_생성.statusCode()).isEqualTo(HttpStatus.CREATED.value());

        ExtractableResponse<Response> response = 지하철_노선_조회(1L);
        하행선값_검증(response, "선릉역");
}
```

- [x] AccessLevel 설정하여 만들기

```java
@Entity
@Getter
@NoArgsConstructor(access = AccessLevel.PROTECTED)
@EqualsAndHashCode
public class Section {
    
}
```

- [x] 도메인쪽에 Applcaiton Layer 참조하지 않고 사용하기

dto 에서 만들어 사용함.
```java
public StationLine toEntity() {
        return StationLine.builder()
            .name(name)
            .color(color)
            .upStationId(upStationId)
            .downStationId(downStationId)
            .distance(distance)
            .build();
    }
```

### 기능 정리

- [x] 구간 등록 기능추가
  - [x] (예외) 새로운 구간의 상행역은 해당 노선에 등록되어있는 하행 종점역이어야 한다.
  - [x] (예외) 새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.

- [x] 구간 삭제 기능 추가
  - [x] (예외) 지하철 노선에 등록된 역(하행 종점역)만 제거할 수 있다. 즉, 마지막 구간만 제거할 수 있다.
  - [x] (예외) 지하철 노선에 상행 종점역과 하행 종점역만 있는 경우(구간이 1개인 경우) 역을 삭제할 수 없다.

### 테스트 케이스 추가

- [x] 구간 등록 테스트 작성
- [x] 구간 하행 종점역만 등록 가능하도록 예외 테스트 작성
- [x] 중복된 역은 추가 될수 없다.


- [x] 구간 삭제
- [x] 마지막 구간만 제거 되도록 테스트 코드 작성
- [x] (구간이 1개인 경우) 역을 삭제할 수 없다 테스트 코드 작성