### PR TITLE
step3 지하철 구간 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    //guava
+    implementation 'com.google.guava:guava:r05'
+
     // log
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -1,0 +1,63 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.LineRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+
+@Service
+@Transactional(readOnly = true)
+public class LineService {
+    private LineRepository lineRepository;
+    private StationService stationService;
+    public LineService(LineRepository lineRepository, StationService stationService){
+        this.lineRepository = lineRepository;
+        this.stationService = stationService;
+    }
+    @Transactional
+    public LineResponse saveLine(LineRequest lineRequest){
+        Line line = lineRepository.save(new Line(lineRequest));
+        return createLineResponse(line);
+    }
+    @Transactional
+    public void updateLine(Long id, LineRequest lineRequest){
+        Line line = lineRepository.findById(id).get();
+        lineRepository.updateNameAndColor(line.getId(), lineRequest.getName(), lineRequest.getColor());
+    }
+
+    @Transactional
+    public void deleteLineById(Long id){
+        lineRepository.deleteById(id);
+    }
+
+
+
+    public List<LineResponse> findAllLines(){
+        return lineRepository.findAll().stream()
+                .map(this::createLineResponse)
+                .collect(Collectors.toList());
+    }
+
+    public LineResponse findLineById(Long id){
+        Optional<Line> line = lineRepository.findById(id);
+        if(line.isPresent()){
+            this.createLineResponse(line.get());
+        }
+        return null;
+    }
+
+    private LineResponse createLineResponse(Line line){
+        LineResponse response = new LineResponse(line);
+        response.setStation(stationService.findStationById(line.getUpStationId()));
+        response.setStation(stationService.findStationById(line.getDownStationId()));
+        return response;
+    }
+
+}

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -48,7 +48,7 @@ public class LineService {
     public LineResponse findLineById(Long id){
         Optional<Line> line = lineRepository.findById(id);
         if(line.isPresent()){
-            this.createLineResponse(line.get());
+            return this.createLineResponse(line.get());
         }
         return null;
     }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -2,8 +2,11 @@ package nextstep.subway.applicaion;
 
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.dto.SectionResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.LineRepository;
+import nextstep.subway.domain.Section;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,11 +19,13 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class LineService {
     private LineRepository lineRepository;
-    private StationService stationService;
-    public LineService(LineRepository lineRepository, StationService stationService){
+    private SectionService sectionService;
+
+    public LineService(LineRepository lineRepository, SectionService sectionService) {
         this.lineRepository = lineRepository;
-        this.stationService = stationService;
+        this.sectionService = sectionService;
     }
+
     @Transactional
     public LineResponse saveLine(LineRequest lineRequest){
         Line line = lineRepository.save(new Line(lineRequest));
@@ -45,7 +50,8 @@ public class LineService {
                 .collect(Collectors.toList());
     }
 
-    public LineResponse findLineById(Long id){
+
+    public LineResponse findLineById(Long id) {
         Optional<Line> line = lineRepository.findById(id);
         if(line.isPresent()){
             return this.createLineResponse(line.get());
@@ -53,11 +59,13 @@ public class LineService {
         return null;
     }
 
-    private LineResponse createLineResponse(Line line){
+    private LineResponse createLineResponse(Line line) {
         LineResponse response = new LineResponse(line);
-        response.setStation(stationService.findStationById(line.getUpStationId()));
-        response.setStation(stationService.findStationById(line.getDownStationId()));
+        List<SectionResponse> sections = sectionService.findAllByLineId(line.getId());
+        if(sections.size()!=0){
+            response.setSections(sections);
+        }
+
         return response;
     }
-
 }

--- a/src/main/java/nextstep/subway/applicaion/SectionService.java
+++ b/src/main/java/nextstep/subway/applicaion/SectionService.java
@@ -1,0 +1,93 @@
+package nextstep.subway.applicaion;
+
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.dto.SectionResponse;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.SectionRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class SectionService {
+    private SectionRepository sectionRepository;
+    private StationService stationService;
+
+    public SectionService(SectionRepository sectionRepository, StationService stationService) {
+        this.sectionRepository = sectionRepository;
+        this.stationService = stationService;
+    }
+
+    public boolean checkRegistPreCodition(Long id, SectionRequest sectionRequest) {
+        //최근 등록된 구간 확인
+        Section recentSection = sectionRepository.findTop1ByLineIdOrderByIdDesc(id);
+
+        if (!recentSection.getDownStationId().equals(sectionRequest.getUpStationId())) {
+            return false;
+        }
+
+        //해당 노선에 등록여부 확인
+        Section alreadyRegistSection = sectionRepository.findByLineIdByStationId(id, sectionRequest.getDownStationId());
+        if (alreadyRegistSection != null) {
+            return false;
+        }
+        return true;
+    }
+
+    public boolean checkDeletePreCondition(Long id, Long stationId){
+        //최근 등록된 구간 확인
+        Section recentSection = sectionRepository.findTop1ByLineIdOrderByIdDesc(id);
+
+        if(!recentSection.getUpStationId().equals(stationId)){
+            return false;
+        }
+
+        //해당 노선의 구간개수 확인
+        List<SectionResponse> sections = findAllByLineId(id);
+        if(sections.size() <=1){
+            return false;
+        }
+        return true;
+    }
+
+    @Transactional
+    public SectionResponse saveSection(Long id, SectionRequest sectionRequest) {
+        Section section = sectionRepository.save(new Section(sectionRequest));
+        section.setLineId(id);
+        return createSectionResponse(section);
+    }
+
+    @Transactional
+    public void deleteByStationId(Long stationId) {
+        sectionRepository.deleteByUpStationId(stationId);
+    }
+
+    @Transactional
+    public void deleteAllByLineId(Long lineId) {
+        sectionRepository.deleteAllByLineId(lineId);
+    }
+
+    public List<SectionResponse> findAllByLineId(Long lineId) {
+        List<Section> sections = sectionRepository.findByLineId(lineId);
+        return createSectionResponses(sections);
+    }
+
+    private SectionResponse createSectionResponse(Section section) {
+        SectionResponse response = new SectionResponse(section);
+        response.setStation(stationService.findStationById(section.getUpStationId()));
+        response.setStation(stationService.findStationById(section.getDownStationId()));
+        return response;
+    }
+
+    private List<SectionResponse> createSectionResponses(List<Section> sections) {
+        List<SectionResponse> response = new ArrayList<>();
+        for (Section section : sections) {
+            response.add(createSectionResponse(section));
+        }
+        return response;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/StationService.java
+++ b/src/main/java/nextstep/subway/applicaion/StationService.java
@@ -8,12 +8,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @Transactional(readOnly = true)
 public class StationService {
-    private StationRepository stationRepository;
+    private final StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;
@@ -41,5 +42,10 @@ public class StationService {
                 station.getId(),
                 station.getName()
         );
+    }
+    @Transactional
+    public Station findStationById(Long id){
+        Optional<Station> station = stationRepository.findById(id);
+        return station.orElse(null);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -1,0 +1,30 @@
+package nextstep.subway.applicaion.dto;
+
+public class LineRequest {
+
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private Long distance;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Long getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,7 +1,6 @@
 package nextstep.subway.applicaion.dto;
 
 import nextstep.subway.domain.Line;
-import nextstep.subway.domain.Station;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,17 +9,20 @@ public class LineResponse {
     private Long id;
     private String name;
     private String color;
-    private List<Station> stations;
+    private Long upStationId;
+    private Long downStationId;
+    private Long distance;
+    private List<SectionResponse> sections;
 
     public LineResponse(Line line) {
         this.id = line.getId();
         this.name = line.getName();
         this.color = line.getColor();
-        stations = new ArrayList<>();
+        this.sections = new ArrayList<>();
+        this.upStationId = 0L;
+        this.downStationId = 0L;
+        this.distance = 0L;
 
-    }
-    public void setStation(Station station){
-        stations.add(station);
     }
 
     public Long getId() {
@@ -35,7 +37,41 @@ public class LineResponse {
         return color;
     }
 
-    public List<Station> getStations() {
-        return stations;
+    public Long getUpStationId() {
+        return upStationId;
     }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Long getDistance() {
+        return distance;
+    }
+
+    public List<SectionResponse> getSections() {
+        return sections;
+    }
+
+    public void addSection(SectionResponse section) {
+        this.sections.add(section);
+        this.distance += section.getDistance();
+        if(this.upStationId.equals(0L)){
+            this.upStationId = section.getUpStationId();
+        }
+        this.downStationId = section.getDownStationid();
+    }
+
+    public void setSections(List<SectionResponse> sections) {
+        this.sections.addAll(sections);
+        for (SectionResponse section : sections) {
+            if(this.upStationId.equals(0L)){
+                this.upStationId = section.getUpStationId();
+            }
+            this.distance += section.getDistance();
+        }
+        this.downStationId = this.sections.get(sections.size()-1).getDownStationid();
+    }
+
+
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -1,0 +1,39 @@
+package nextstep.subway.applicaion.dto;
+
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Station;
+
+import java.util.List;
+
+public class LineResponse {
+    private Long id;
+    private String name;
+    private String color;
+    private List<Station> stations;
+
+    public LineResponse(Line line) {
+        this.id = line.getId();
+        this.name = line.getName();
+        this.color = line.getColor();
+
+    }
+    public void setStation(Station station){
+        stations.add(station);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public List<Station> getStations() {
+        return stations;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineResponse.java
@@ -3,6 +3,7 @@ package nextstep.subway.applicaion.dto;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Station;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public class LineResponse {
@@ -15,6 +16,7 @@ public class LineResponse {
         this.id = line.getId();
         this.name = line.getName();
         this.color = line.getColor();
+        stations = new ArrayList<>();
 
     }
     public void setStation(Station station){

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -1,0 +1,32 @@
+package nextstep.subway.applicaion.dto;
+
+import nextstep.subway.domain.Line;
+
+public class SectionRequest {
+
+    private Long upStationId;
+    private Long downStationId;
+    private Long distance;
+
+    public SectionRequest(){
+
+    }
+
+    public SectionRequest(LineRequest lineRequest) {
+        this.upStationId = lineRequest.getUpStationId();
+        this.downStationId = lineRequest.getDownStationId();
+        this.distance = lineRequest.getDistance();
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Long getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionResponse.java
@@ -1,0 +1,53 @@
+package nextstep.subway.applicaion.dto;
+
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Station;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class SectionResponse {
+    private Long id;
+    private Long lineId;
+    private Long upStationId;
+    private Long downStationid;
+    private Long distance;
+    private List<Station> stations;
+
+    public SectionResponse(Section section) {
+        this.id = section.getId();
+        this.lineId = section.getLineId();
+        this.upStationId = section.getUpStationId();
+        this.downStationid = section.getDownStationId();
+        this.distance = section.getDistance();
+        this.stations  = new ArrayList<>();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getLineId() {
+        return lineId;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationid() {
+        return downStationid;
+    }
+
+    public Long getDistance() {
+        return distance;
+    }
+
+    public List<Station> getStations() {
+        return stations;
+    }
+
+    public void setStation(Station station){
+        stations.add(station);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -16,9 +16,7 @@ public class Line {
     private Long id;
     private String name;
     private String color;
-    private Long upStationId;
-    private Long downStationId;
-    private Long distance;
+
 
     public Line() {
     }
@@ -26,9 +24,6 @@ public class Line {
     public Line(LineRequest lineRequest){
         this.name = lineRequest.getName();
         this.color = lineRequest.getColor();
-        this.upStationId = lineRequest.getUpStationId();
-        this.downStationId = lineRequest.getDownStationId();
-        this.distance = lineRequest.getDistance();
     }
 
     public Long getId() {
@@ -43,15 +38,4 @@ public class Line {
         return color;
     }
 
-    public Long getUpStationId() {
-        return upStationId;
-    }
-
-    public Long getDownStationId() {
-        return downStationId;
-    }
-
-    public Long getDistance() {
-        return distance;
-    }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -1,0 +1,57 @@
+package nextstep.subway.domain;
+
+import nextstep.subway.applicaion.dto.LineRequest;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import java.util.List;
+
+@Entity
+public class Line {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private Long distance;
+
+    public Line() {
+    }
+
+    public Line(LineRequest lineRequest){
+        this.name = lineRequest.getName();
+        this.color = lineRequest.getColor();
+        this.upStationId = lineRequest.getUpStationId();
+        this.downStationId = lineRequest.getDownStationId();
+        this.distance = lineRequest.getDistance();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Long getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/LineRepository.java
+++ b/src/main/java/nextstep/subway/domain/LineRepository.java
@@ -1,0 +1,12 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+
+    @Modifying
+    @Query("UPDATE Line l SET l.name = :name, l.color = :color WHERE l.id = :id ")
+    void updateNameAndColor(Long id, String name , String color);
+}

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -1,0 +1,69 @@
+package nextstep.subway.domain;
+
+import nextstep.subway.applicaion.dto.SectionRequest;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Section {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private Long lineId;
+    private Long upStationId;
+    private Long downStationId;
+    private Long distance;
+
+    public Section() {
+    }
+
+    public Section(SectionRequest sectionRequest) {
+        this.upStationId =  sectionRequest.getUpStationId();
+        this.downStationId = sectionRequest.getDownStationId();
+        this.distance = sectionRequest.getDistance();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getLineId() {
+        return lineId;
+    }
+
+    public void setLineId(Long lineId) {
+        this.lineId = lineId;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public void setUpStationId(Long upStationId) {
+        this.upStationId = upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public void setDownStationId(Long downStationId) {
+        this.downStationId = downStationId;
+    }
+
+    public Long getDistance() {
+        return distance;
+    }
+
+    public void setDistance(Long distance) {
+        this.distance = distance;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/SectionRepository.java
+++ b/src/main/java/nextstep/subway/domain/SectionRepository.java
@@ -1,0 +1,22 @@
+package nextstep.subway.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface SectionRepository extends JpaRepository<Section, Long> {
+
+    //특정 노선에 대한 구간 조회
+    List<Section> findByLineId(Long lineId);
+    void deleteByUpStationId(Long upStationId);
+    void deleteAllByLineId(Long lineId);
+    //최신 저장한 구간 조회
+    Section findTop1ByLineIdOrderByIdDesc(Long lineId);
+
+    //사전 등록 여부 확인
+    @Query("FROM Section s WHERE s.lineId =:lineId AND (s.upStationId = :downStationId OR s.downStationId = :downStationId)")
+    Section findByLineIdByStationId(Long lineId, Long downStationId);
+
+}

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,8 +1,10 @@
 package nextstep.subway.ui;
 
 import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.SectionService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
+import nextstep.subway.applicaion.dto.SectionRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -12,14 +14,17 @@ import java.util.List;
 @RestController
 public class LineController {
     private LineService lineService;
+    private SectionService sectionService;
 
-    public LineController(LineService lineService) {
+    public LineController(LineService lineService, SectionService sectionService) {
         this.lineService = lineService;
+        this.sectionService = sectionService;
     }
 
     @PostMapping("/lines")
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         LineResponse line = lineService.saveLine(lineRequest);
+        line.addSection(sectionService.saveSection(line.getId(), new SectionRequest(lineRequest)));
         return ResponseEntity.created(URI.create("/lines/"+line.getId())).body(line);
     }
 
@@ -41,6 +46,7 @@ public class LineController {
 
     @DeleteMapping("/lines/{id}")
     public ResponseEntity<Void> deleteLine(@PathVariable Long id){
+        sectionService.deleteAllByLineId(id);
         lineService.deleteLineById(id);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,10 +1,8 @@
 package nextstep.subway.ui;
 
 import nextstep.subway.applicaion.LineService;
-import nextstep.subway.applicaion.StationService;
 import nextstep.subway.applicaion.dto.LineRequest;
 import nextstep.subway.applicaion.dto.LineResponse;
-import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,11 +12,9 @@ import java.util.List;
 @RestController
 public class LineController {
     private LineService lineService;
-    private StationService stationService;
 
-    public LineController(LineService lineService, StationService stationService) {
+    public LineController(LineService lineService) {
         this.lineService = lineService;
-        this.stationService = stationService;
     }
 
     @PostMapping("/lines")

--- a/src/main/java/nextstep/subway/ui/LineController.java
+++ b/src/main/java/nextstep/subway/ui/LineController.java
@@ -1,0 +1,52 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.applicaion.LineService;
+import nextstep.subway.applicaion.StationService;
+import nextstep.subway.applicaion.dto.LineRequest;
+import nextstep.subway.applicaion.dto.LineResponse;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+public class LineController {
+    private LineService lineService;
+    private StationService stationService;
+
+    public LineController(LineService lineService, StationService stationService) {
+        this.lineService = lineService;
+        this.stationService = stationService;
+    }
+
+    @PostMapping("/lines")
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+        LineResponse line = lineService.saveLine(lineRequest);
+        return ResponseEntity.created(URI.create("/lines/"+line.getId())).body(line);
+    }
+
+    @GetMapping("/lines")
+    public ResponseEntity<List<LineResponse>> showLines(){
+        return ResponseEntity.ok().body(lineService.findAllLines());
+    }
+
+    @GetMapping("/lines/{id}")
+    public ResponseEntity<LineResponse> showLine(@PathVariable Long id){
+        return ResponseEntity.ok().body(lineService.findLineById(id));
+    }
+
+    @PutMapping("/lines/{id}")
+    public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest){
+        lineService.updateLine(id, lineRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/lines/{id}")
+    public ResponseEntity<Void> deleteLine(@PathVariable Long id){
+        lineService.deleteLineById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/nextstep/subway/ui/SectionController.java
+++ b/src/main/java/nextstep/subway/ui/SectionController.java
@@ -1,0 +1,38 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.applicaion.SectionService;
+import nextstep.subway.applicaion.dto.SectionRequest;
+import nextstep.subway.applicaion.dto.SectionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class SectionController {
+
+    public SectionService sectionService;
+
+    public SectionController(SectionService sectionService) {
+        this.sectionService = sectionService;
+    }
+
+    @PostMapping("/lines/{id}/sections")
+    public ResponseEntity<SectionResponse> registSection(@PathVariable Long id, @RequestBody SectionRequest sectionRequest) {
+        boolean preCondition = sectionService.checkRegistPreCodition(id, sectionRequest);
+        if(!preCondition){
+            return ResponseEntity.internalServerError().build();
+        }
+        SectionResponse response = sectionService.saveSection(id, sectionRequest);
+        return ResponseEntity.ok().body(response);
+    }
+
+    @DeleteMapping("/lines/{id}/sections")
+    public ResponseEntity<Void> deleteSection(@PathVariable Long id, @RequestParam Long stationId) {
+        boolean preCondition = sectionService.checkDeletePreCondition(id, stationId);
+        if(!preCondition){
+            return ResponseEntity.internalServerError().build();
+        }
+        sectionService.deleteByStationId(stationId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/resources/stations.sql
+++ b/src/main/resources/stations.sql
@@ -1,0 +1,3 @@
+INSERT INTO STATION(id, name) VALUES(1, '강남역');
+INSERT INTO STATION(id, name) VALUES(2, '양재역');
+INSERT INTO STATION(id, name) VALUES(3, '교대역');

--- a/src/main/resources/stations.sql
+++ b/src/main/resources/stations.sql
@@ -1,3 +1,0 @@
-INSERT INTO STATION(id, name) VALUES(1, '강남역');
-INSERT INTO STATION(id, name) VALUES(2, '양재역');
-INSERT INTO STATION(id, name) VALUES(3, '교대역');

--- a/src/test/java/nextstep/subway/acceptance/DatabaseTruncator.java
+++ b/src/test/java/nextstep/subway/acceptance/DatabaseTruncator.java
@@ -1,0 +1,44 @@
+package nextstep.subway.acceptance;
+
+import com.google.common.base.CaseFormat;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Profile("tableTruncator")
+public class DatabaseTruncator implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private List<String> tableNames;
+
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        tableNames = entityManager.getMetamodel().getEntities().stream()
+                .filter(entity -> entity.getJavaType().getAnnotation(Entity.class) != null)
+                .map(entity -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, entity.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void cleanTable() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN " + "ID RESTART WITH 1").executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -70,7 +70,7 @@ public class LineAcceptanceTest {
     }
 
     @AfterEach
-    void tableClear(){
+    void tableClear() {
         databaseTruncator.cleanTable();
     }
 
@@ -109,11 +109,8 @@ public class LineAcceptanceTest {
         restUtil.createEntityData(line2, "/lines");
 
         //when
-        List<String> names = RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/lines")
-                .then().log().all()
-                .extract().jsonPath().getList("name", String.class);
+        List<String> names = restUtil.getResponseData("/lines")
+                .jsonPath().getList("name", String.class);
 
         //then
         assertThat(names).containsAnyOf(line1.get("name").toString(), line2.get("name").toString());
@@ -128,12 +125,7 @@ public class LineAcceptanceTest {
         Long id = restUtil.createEntityData(line1, "/lines");
 
         //when
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().get("/lines/{id}", id)
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = restUtil.getResponseDataById("/lines/{id}", id);
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
 
@@ -176,12 +168,7 @@ public class LineAcceptanceTest {
         Long id = restUtil.createEntityData(line1, "/lines");
 
         //when
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().delete("/lines/{id}", id)
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = restUtil.deleteEntityDataById("/lines/{id}", id);
 
         //then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,12 +1,26 @@
 package nextstep.subway.acceptance;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.jdbc.Sql;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DirtiesContext
 @DisplayName("지하철 노선 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class LineAcceptanceTest {
@@ -14,37 +28,147 @@ public class LineAcceptanceTest {
     int port;
 
     @BeforeEach
-    public void setUp(){
+    public void setUp() {
         RestAssured.port = port;
     }
 
-    @DisplayName("지하철노선을 생성한다.")
-    @Test
-    void createLine(){
+    private static Map<String, Object> line1;
+    private static Map<String, Object> line2;
+
+
+    @BeforeAll
+    @Sql("classpath:/stations.sql")
+    static void init() {
+        line1 = new HashMap<>();
+        line1.put("name", "신분당선");
+        line1.put("color", "bg-red-600");
+        line1.put("upStationId", 1);
+        line1.put("downStationId", 2);
+        line1.put("distance", 10);
+
+        line2 = new HashMap<>();
+        line2.put("name", "2호선");
+        line2.put("color", "bg-green-600");
+        line2.put("upStationId", 1);
+        line2.put("downStationId", 3);
+        line2.put("distance", 10);
 
     }
+
+
+    @DisplayName("지하철노선을 생성한다.")
+    @Test
+    void createLine() {
+        //when
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(line1)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/lines")
+                        .then().log().all()
+                        .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        String location = response.response().getHeader("Location");
+
+    }
+
     @DisplayName("지하철노선 목록을 조회한다.")
     @Test
-    void getLines(){
+    void getLines() {
+        //given
+        createLine(line1);
+        createLine(line2);
 
+        //when
+        List<String> names = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/lines")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+
+        //then
+        assertThat(names).containsAnyOf(line1.get("name").toString(), line2.get("name").toString());
     }
 
     @DisplayName("지하철노선을 조회한다.")
     @Test
-    void getLine(){
+    void getLine() {
+        //given
+        Long id = createLine(line1);
+
+        //when
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().get("/lines/{id}", id)
+                        .then().log().all()
+                        .extract();
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
 
     }
 
     @DisplayName("지하철노선을 수정한다.")
     @Test
-    void updateLine(){
+    void updateLine() {
+        //given
+        Long id = createLine(line1);
+
+        Map<String, String> updateParams = new HashMap<>();
+
+        updateParams.put("name", "구분당선");
+        updateParams.put("color", "bg-orange-600");
+
+        //when
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .body(updateParams)
+                        .when().put("/lines/{id}", id)
+                        .then().log().all()
+                        .extract();
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
 
     }
 
     @DisplayName("지하철노선을 삭제한다.")
     @Test
-    void deleteLine(){
+    void deleteLine() {
+        //given
+        Long id = createLine(line1);
 
+        //when
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().delete("/lines/{id}", id)
+                        .then().log().all()
+                        .extract();
+
+        //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
+
+    Long createLine(Map<String, Object> params) {
+
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(params)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/lines")
+                        .then().log().all()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        String location = response.header("Location");
+        String[] args = location.split("/");
+        return Long.parseLong(args[args.length-1]);
+    }
+
 
 }

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.HashMap;
@@ -19,7 +18,6 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 노선 관련 기능")
-//@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles("tableTruncator")
 public class LineAcceptanceTest {

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -20,8 +20,9 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DirtiesContext
 @DisplayName("지하철 노선 관련 기능")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@Sql("classpath:/stations.sql")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class LineAcceptanceTest {
     @LocalServerPort
@@ -37,7 +38,6 @@ public class LineAcceptanceTest {
 
 
     @BeforeAll
-    @Sql("classpath:/stations.sql")
     static void init() {
         line1 = new HashMap<>();
         line1.put("name", "신분당선");

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -1,0 +1,50 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+
+@DisplayName("지하철 노선 관련 기능")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class LineAcceptanceTest {
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setUp(){
+        RestAssured.port = port;
+    }
+
+    @DisplayName("지하철노선을 생성한다.")
+    @Test
+    void createLine(){
+
+    }
+    @DisplayName("지하철노선 목록을 조회한다.")
+    @Test
+    void getLines(){
+
+    }
+
+    @DisplayName("지하철노선을 조회한다.")
+    @Test
+    void getLine(){
+
+    }
+
+    @DisplayName("지하철노선을 수정한다.")
+    @Test
+    void updateLine(){
+
+    }
+
+    @DisplayName("지하철노선을 삭제한다.")
+    @Test
+    void deleteLine(){
+
+    }
+
+}

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -70,7 +70,7 @@ public class LineAcceptanceTest {
     }
 
     @AfterEach
-    void clear(){
+    void tableClear(){
         databaseTruncator.cleanTable();
     }
 

--- a/src/test/java/nextstep/subway/acceptance/RestUtil.java
+++ b/src/test/java/nextstep/subway/acceptance/RestUtil.java
@@ -1,0 +1,28 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RestUtil {
+
+    public Long createEntityData(Map<String, Object> params, String requestUrl) {
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(params)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post(requestUrl)
+                        .then().log().all()
+                        .extract();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        String location = response.header("Location");
+        String[] args = location.split("/");
+        return Long.parseLong(args[args.length-1]);
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/RestUtil.java
+++ b/src/test/java/nextstep/subway/acceptance/RestUtil.java
@@ -21,8 +21,43 @@ public class RestUtil {
                         .then().log().all()
                         .extract();
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-        String location = response.header("Location");
-        String[] args = location.split("/");
-        return Long.parseLong(args[args.length-1]);
+        return ((Number)response.jsonPath().get("id")).longValue();
     }
+    public Long registEntityData(Map<String, Object> params, String requestUrl){
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(params)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post(requestUrl)
+                        .then().log().all()
+                        .extract();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        return ((Number)response.jsonPath().get("id")).longValue();
+    }
+
+    public ExtractableResponse<Response> getResponseData(String requestUrl){
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(requestUrl)
+                .then().log().all()
+                .extract();
+    }
+
+    public ExtractableResponse<Response> getResponseDataById(String requestUrl, Long id){
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(requestUrl, id)
+                .then().log().all()
+                .extract();
+    }
+
+    public ExtractableResponse<Response> deleteEntityDataById(String requestUrl, Long id){
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete(requestUrl, id)
+                .then().log().all()
+                .extract();
+    }
+
+
 }

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,11 +1,20 @@
 package nextstep.subway.acceptance;
 
 import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 구간 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -23,13 +32,59 @@ public class SectionAcceptanceTest {
         databaseTruncator.afterPropertiesSet();
     }
 
+    private static Map<String, Object> line1;
+    private static Map<String, Object> section1;
+    private static Map<String, Object> section2;
+    private static Map<String, Object> section3;
+    private static Map<String, Object> station1;
+    private static Map<String, Object> station2;
+    private static Map<String, Object> station3;
+    private static Map<String, Object> station4;
+
+    static RestUtil restUtil;
+
     @BeforeAll
-    static void init(){
+    static void init() {
+        restUtil = new RestUtil();
+        line1 = new HashMap<>();
+        line1.put("name", "신분당선");
+        line1.put("color", "bg-red-600");
+        line1.put("upStationId", 1);
+        line1.put("downStationId", 2);
+        line1.put("distance", 10);
+
+        section1 = new HashMap<>();
+        section1.put("upStationId", 2);
+        section1.put("downStationId", 3);
+        section1.put("distance", 10);
+
+        section2 = new HashMap<>();
+        section2.put("upStationId", 3);
+        section2.put("downStationId", 4);
+        section2.put("distance", 10);
+
+        section3 = new HashMap<>();
+        section3.put("upStationId", 2);
+        section3.put("downStationId", 1);
+        section3.put("distance", 10);
+
+        station1 = new HashMap<>();
+        station1.put("name", "강남역");
+
+        station2 = new HashMap<>();
+        station2.put("name", "양재역");
+
+        station3 = new HashMap<>();
+        station3.put("name", "교대역");
+
+        station4 = new HashMap<>();
+        station4.put("name", "신촌역");
+
 
     }
 
     @AfterEach
-    void tableClear(){
+    void tableClear() {
         databaseTruncator.cleanTable();
     }
 
@@ -39,8 +94,75 @@ public class SectionAcceptanceTest {
      * */
     @DisplayName("지하철 구간을 등록한다")
     @Test
-    void registerSection(){
+    void registerSection() {
+        restUtil.createEntityData(station1, "/stations");
+        restUtil.createEntityData(station2, "/stations");
+        restUtil.createEntityData(station3, "/stations");
+        restUtil.createEntityData(station4, "/stations");
+        Long id = restUtil.createEntityData(line1, "/lines");
 
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(section1)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/lines/" + id + "/sections")
+                        .then().log().all()
+                        .extract();
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        ExtractableResponse<Response> response2 =
+                RestAssured.given().log().all()
+                        .body(section2)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/lines/" + id + "/sections")
+                        .then().log().all()
+                        .extract();
+        assertThat(response2.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+
+        ExtractableResponse<Response> lineResponse = restUtil.getResponseDataById("/lines/{id}", id);
+
+        assertThat(lineResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+
+    }
+
+    @DisplayName("등록된 노선의 하행과 새로 등록할 구간의 상행이 맞지 않으면 등록할 수 없다.")
+    @Test
+    void matchStation() {
+        restUtil.createEntityData(station1, "/stations");
+        restUtil.createEntityData(station2, "/stations");
+        restUtil.createEntityData(station3, "/stations");
+        restUtil.createEntityData(station4, "/stations");
+        Long id = restUtil.createEntityData(line1, "/lines");
+
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(section2)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/lines/" + id + "/sections")
+                        .then().log().all()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+
+    @DisplayName("등록할 구간의 하행은 이미 등록되어 있으면 안된다")
+    @Test
+    void checkDuplicate(){
+        restUtil.createEntityData(station1, "/stations");
+        restUtil.createEntityData(station2, "/stations");
+        Long id = restUtil.createEntityData(line1, "/lines");
+
+        ExtractableResponse<Response> response =
+                RestAssured.given().log().all()
+                        .body(section3)
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post("/lines/" + id + "/sections")
+                        .then().log().all()
+                        .extract();
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
     }
 
     /*
@@ -50,7 +172,62 @@ public class SectionAcceptanceTest {
      * */
     @DisplayName("지하철 구간을 삭제한다")
     @Test
-    void deleteSection(){
+    void deleteSection() {
+        restUtil.createEntityData(station1, "/stations");
+        restUtil.createEntityData(station2, "/stations");
+        restUtil.createEntityData(station3, "/stations");
+        Long id = restUtil.createEntityData(line1, "/lines");
+        restUtil.registEntityData(section1, "/lines/" + id + "/sections");
+
+        ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .given().queryParam("stationId", section1.get("upStationId"))
+                .when().delete("/lines/{id}/sections", id)
+                .then().log().all()
+                .extract();
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
+        ExtractableResponse<Response> lineResponse = restUtil.getResponseDataById("/lines/{id}", id);
+        assertThat(lineResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+    }
+
+    @DisplayName("한개의 구간만 지닌 노선의 구간을 삭제할 수 없다.")
+    @Test
+    void canNotDeleteOneSection() {
+        restUtil.createEntityData(station1, "/stations");
+        restUtil.createEntityData(station2, "/stations");
+        Long id = restUtil.createEntityData(line1, "/lines");
+
+        ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .given().queryParam("stationId", line1.get("upStationId"))
+                .when().delete("/lines/{id}/sections", id)
+                .then().log().all()
+                .extract();
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+
+
+    }
+
+    @DisplayName("마지막 구간이 아닌 것은 제거 할 수 없다.")
+    @Test
+    void deleteOnlyDownSation() {
+        restUtil.createEntityData(station1, "/stations");
+        restUtil.createEntityData(station2, "/stations");
+        restUtil.createEntityData(station3, "/stations");
+        restUtil.createEntityData(station4, "/stations");
+        Long id = restUtil.createEntityData(line1, "/lines");
+        restUtil.registEntityData(section1, "/lines/" + id + "/sections");
+        restUtil.registEntityData(section2, "/lines/" + id + "/sections");
+
+        ExtractableResponse<Response> deleteResponse = RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .given().queryParam("stationId", section1.get("upStationId"))
+                .when().delete("/lines/{id}/sections", id)
+                .then().log().all()
+                .extract();
+        assertThat(deleteResponse.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
 
     }
 

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -1,0 +1,58 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+@DisplayName("지하철 구간 관련 기능")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("tableTruncator")
+public class SectionAcceptanceTest {
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private DatabaseTruncator databaseTruncator;
+
+    @BeforeEach
+    public void setUp() throws Exception {
+        RestAssured.port = port;
+        databaseTruncator.afterPropertiesSet();
+    }
+
+    @BeforeAll
+    static void init(){
+
+    }
+
+    @AfterEach
+    void tableClear(){
+        databaseTruncator.cleanTable();
+    }
+
+    /*
+     * When 지하철 노선에 지하철 구간을 등록하면
+     * Then 지하철 노선 조회 시 등록한 지하철 구간을 확인할 수 있다
+     * */
+    @DisplayName("지하철 구간을 등록한다")
+    @Test
+    void registerSection(){
+
+    }
+
+    /*
+     * Given 지하철 노선에 지하철 구간을 등록하고
+     * when 등록한 지하설 구간을 삭제하면
+     * Then 해당 지하철 구간은 삭제된다
+     * */
+    @DisplayName("지하철 구간을 삭제한다")
+    @Test
+    void deleteSection(){
+
+    }
+
+}
+

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -53,7 +53,7 @@ public class StationAcceptanceTest {
     }
 
     @AfterEach
-    void tableClear(){
+    void tableClear() {
         databaseTruncator.cleanTable();
     }
 
@@ -105,7 +105,8 @@ public class StationAcceptanceTest {
 
 
         //when
-        List<String> names = getAllStations();
+        List<String> names = restUtil.getResponseData("/stations")
+                .jsonPath().getList("name", String.class);
 
         //then
         assertThat(names).containsAnyOf(station1.get("name").toString(), station2.get("name").toString());
@@ -125,33 +126,14 @@ public class StationAcceptanceTest {
         Long id = restUtil.createEntityData(station3, "/stations");
 
         //when
-        deleteStations(id);
+        ExtractableResponse<Response> response = restUtil.deleteEntityDataById("/stations/{id}", id);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 
         //then
-        List<String> names = getAllStations();
+        List<String> names = restUtil.getResponseData("/stations")
+                .jsonPath().getList("name", String.class);
         assertThat(names).doesNotContain(station3.get("name").toString());
 
 
     }
-
-    public List<String> getAllStations() {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/stations")
-                .then().log().all()
-                .extract().jsonPath().getList("name", String.class);
-    }
-
-    public void deleteStations(Long id) {
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().delete("/stations/{id}", id)
-                        .then().log().all()
-                        .extract();
-
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-    }
-
-
 }

--- a/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/StationAcceptanceTest.java
@@ -3,14 +3,13 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.HashMap;
 import java.util.List;
@@ -20,13 +19,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("tableTruncator")
 public class StationAcceptanceTest {
     @LocalServerPort
     int port;
 
+    @Autowired
+    private DatabaseTruncator databaseTruncator;
+
     @BeforeEach
-    public void setUp() {
+    public void setUp() throws Exception {
         RestAssured.port = port;
+        databaseTruncator.afterPropertiesSet();
     }
 
     private static Map<String, Object> station1;
@@ -46,6 +50,11 @@ public class StationAcceptanceTest {
 
         station3 = new HashMap<>();
         station3.put("name", "마곡나루역");
+    }
+
+    @AfterEach
+    void tableClear(){
+        databaseTruncator.cleanTable();
     }
 
 


### PR DESCRIPTION
안녕하세요 브라운님 

교육생 김성태 입니다. 

죄송합니다. 슬랙으로 DM도 주셨는데 알림 확인이 늦었습니다 ㅜㅜ
시간이 오래 걸렸습니다.. 중간에 워크샵 일정이 있긴 했지만 ㅠ 핑계 같습니다. 
이제 워크샵도 끝났으니 미뤄진 만큼 열심히 달려보고자 합니다( 꼭 그렇게 하겠습니다) 

step3에서 Section이 생김으로써 여러가지 생각을 해보고 구현 및 리팩토링을 했습니다. 


1. Line을 크게(?) 수정했습니다. 
- Line 엔티티는 이름과 색상 정보만 가지도록 했고 Line Response의 경우 바로 Stations를 보여주는게 아니라 
Section정보와 그 안에 Station이 보여지도록 했습니다.(Section이라는 엔티티가 추가됨으로써 그게 맞지 않을까 생각했습니다.)
- 기존에 Line에서 담당했던 것들 대부분 Section이 일임하게 만들었습니다. 
- 기존 up, down, distance는 Section의 정보를 기반으로 데이터를 가져올 수 있도록 하였습니다. 
- 수정함에 따라서 테스트 코드의 테스트 방식도 일부 변경하였습니다. 

2. Section 기능 구현 및 테스트 코드를 작성했습니다. 
- 엔티티 자체에는 Up, Down Station 정보와 distance만 구성하였고 Response에서 상세 데이터를 다루게 했습니다. 
- 테스트는 등록 및 삭제 를 기반으로 예외처리에 대해서도 제대로 적용됬는지 확인하기 위해 테스트 코드를 작성했습니다. 

이번 과제를 하면서 혼자만의 생각으로 하다가 원점으로 돌아간 경우도 있었는데, 
저번처럼 적극적으로  문의 드리고 피드백 받아서 적용할 수 있도록 해보겠습니다.
열심히 해보겠습니다!! 