### PR TITLE
1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -84,15 +84,16 @@ public class StationAcceptanceTest {
     @Test
     void deleteStation() {
         // given
-        ExtractableResponse<Response> saved = insertStation("강남역");
+        Long savedStationId = insertStation("강남역").jsonPath().getLong(STATION_ID_KEY);
 
         // when
-        ExtractableResponse<Response> response = deleteStation(saved.jsonPath().getLong(STATION_ID_KEY));
+        ExtractableResponse<Response> response = deleteStation(savedStationId);
 
         // then
         assertAll(
             () -> assertThat(response.body().asString()).isBlank(),
-            () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value())
+            () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value()),
+            () -> assertThat(allStations().jsonPath().getList(STATION_ID_KEY, Long.class)).doesNotContain(savedStationId)
         );
     }
 

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -1,19 +1,19 @@
 package subway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -56,6 +56,37 @@ public class StationAcceptanceTest {
      * Then 2개의 지하철역을 응답 받는다
      */
     // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역 목록을 조회한다.")
+    @Test
+    void readStationList() {
+        // given
+        RestAssured.given().log().all()
+            .body(Map.of("name", "강남역"))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/stations")
+            .then().log().all()
+            .extract();
+
+        RestAssured.given().log().all()
+            .body(Map.of("name", "양재역"))
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/stations")
+            .then().log().all()
+            .extract();
+
+        // when
+        ExtractableResponse<Response> response =
+            RestAssured.when().get("/stations")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertAll(
+            () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+            () -> assertThat(response.jsonPath().getList("name")).containsExactly("강남역", "양재역"),
+            () -> assertThat(response.header("Content-Type")).isEqualTo("application/json")
+        );
+    }
 
     /**
      * Given 지하철역을 생성하고

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -69,7 +69,7 @@ public class StationAcceptanceTest {
         // then
         assertAll(
             () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-            () -> assertThat(response.jsonPath().getList(STATION_NAME_KEY)).containsExactly("강남역", "양재역"),
+            () -> assertThat(response.jsonPath().getList(STATION_NAME_KEY, String.class)).containsExactly("강남역", "양재역"),
             () -> assertThat(response.contentType()).isEqualTo(MediaType.APPLICATION_JSON_VALUE)
         );
     }


### PR DESCRIPTION
1단계 진행 PR 요청드립니다~ 😄 

# 구현 사항
- 지하철역 목록 조회 인수 테스트 메서드 생성
- 지하철역 제거 인수 테스트 메서드 생성

# 구현 중점 사항
- 전체 테스트시 메소드별 독립된 컨텍스트 유지가 안되어, `@AfterEach` 메소드로 전체 지하철역 정보를 삭제하도록 구현했습니다.
- `insert`, `select all`, `delete` 각각 private 메소드로 추출해 중복 코드 제거하도록 노력했습니다.
- 문자열 값은 상수로 추출했습니다.
- `assertAll` 을 사용해 하나의 실행으로 유발된 결과를 하나의 단위로 검증할 수 있도록 구현했습니다. 
➡️ ❓관련해 1개의 인수 테스트 메소드에서 검증해야 하는 실행단위는 API 1개에 매핑이 되도록 설계하면 될까요?
