### PR TITLE
feature: 구글 페이지 접근 테스트 추가

### DIFF
--- a/src/test/java/subway/RestAssuredTest.java
+++ b/src/test/java/subway/RestAssuredTest.java
@@ -1,23 +1,35 @@
 package subway;
 
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
+import static io.restassured.RestAssured.*;
+import static org.assertj.core.api.Assertions.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class RestAssuredTest {
+
+    private static final String GOOGLE_PAGE_HOST = "https://google.com";
 
     @DisplayName("구글 페이지 접근 테스트")
     @Test
     void accessGoogle() {
         // TODO: 구글 페이지 요청 구현
-        ExtractableResponse<Response> response = null;
 
+        // given
+        ExtractableResponse<Response> response;
+        RestAssured.baseURI = GOOGLE_PAGE_HOST;
+
+        // when
+        response = given().when().get().then().extract();
+
+        // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }


### PR DESCRIPTION
### 알게된 것

1. MockMvc는 주로 개발자가 자신이 개발한 컨트롤러, 필터, 인터셉터 등을 테스트하는 데 사용, 외부 API X

> MockMvc는 서버를 사용하지 않고 Spring MVC를 테스트하기 위한 클래스입니다.  
주로 개발자가 자신이 개발한 컨트롤러, 필터, 인터셉터 등을 테스트하는 데 사용합니다.  
따라서 MockMvc는 외부 서버, 즉 "https://google.com"과 같은 URL에 대한 요청을 보낼 수 없습니다.  
구글과 같은 외부 서비스에 대한 요청을 보내려면, RestTemplate이나 RestAssured 같은 HTTP 클라이언트를 사용하셔야 합니다.  

2. MockMvc와 RestAssured의 차이

> MockMvc는 웹 애플리케이션을 애플리케이션 서버에 배포하지 않고도 스프링 MVC의 동작을 재현할 수 있는 라이브러리
→ 대부분 Controller Layer Unit Test(단위 테스트)에 사용된다.

> RestAssured는 실제 서버 환경과 동일한 @SpringBootTest를 사용하지않고 Presentation Layer Bean들만 불러오고,
그 외 Bean은 Mock 객체 설정을 해주어 순수한 Controller 로직을 테스트한다.
→ HTTP Endpoint에 초점을 맞춘 테스트 도구다.