### PR TITLE
1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/main/java/subway/StationResponse.java
+++ b/src/main/java/subway/StationResponse.java
@@ -4,6 +4,9 @@ public class StationResponse {
     private Long id;
     private String name;
 
+    public StationResponse() {
+    }
+
     public StationResponse(Long id, String name) {
         this.id = id;
         this.name = name;

--- a/src/test/java/subway/RestAssuredTest.java
+++ b/src/test/java/subway/RestAssuredTest.java
@@ -1,22 +1,26 @@
 package subway;
 
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.restassured.RestAssured;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class RestAssuredTest {
+class RestAssuredTest {
 
     @DisplayName("구글 페이지 접근 테스트")
     @Test
     void accessGoogle() {
-        // TODO: 구글 페이지 요청 구현
-        ExtractableResponse<Response> response = null;
+        final var response = RestAssured.given()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("https://google.com")
+                .then()
+                .extract();
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -3,36 +3,22 @@ package subway;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
-import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
+import subway.fixture.AcceptanceTest;
+import subway.fixture.StationFixture;
 
 @DisplayName("지하철역 관련 기능")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
-class StationAcceptanceTest {
+class StationAcceptanceTest extends AcceptanceTest {
 
-    private static final String BASE_URL = "/stations";
-
-    @LocalServerPort
-    int port;
+    private final StationFixture stationFixture = new StationFixture();
 
     @BeforeEach
-    public void setUp() {
-        RestAssured.port = port;
+    public void required() {
+        assertThat(stationFixture.모든_지하철역을_조회한다()).isEmpty();
     }
 
     /**
@@ -45,15 +31,11 @@ class StationAcceptanceTest {
     void createStation() {
         final String name = "강남역";
 
-        // required
-        requiredStationsNotExist(name);
-
         // when
-        final ExtractableResponse<Response> response = createStation(name);
+        stationFixture.지하철역을_생성한다(name);
 
         // then
-        assertStatusCodeEqualTo(response, HttpStatus.CREATED);
-        assertStationCreated(name);
+        assertThat(stationFixture.지하철역을_조회한다(name)).isPresent();
     }
 
     /**
@@ -61,30 +43,21 @@ class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    @DisplayName("지하철역 목록을 조회한다.")
+    @DisplayName("모든 지하철역 목록을 조회한다.")
     @Test
     void showStations() {
-        final List<String> stationNames = List.of("강남역", "역삼역", "선릉역");
-
-        // required
-        requiredStationsNotExist(stationNames);
+        final List<String> names = List.of("강남역", "역삼역");
 
         // given
-        stationNames.forEach(name ->
-                RestAssured.given().log().all()
-                        .body(Map.of("name", name))
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post(BASE_URL)
-                        .then().log().all()
-                        .statusCode(HttpStatus.CREATED.value())
-        );
+        stationFixture.지하철역을_생성한다(names);
 
         // when
-        final ExtractableResponse<Response> response = getAllStations();
+        final var responses = stationFixture.모든_지하철역을_조회한다();
 
         // then
-        assertStatusCodeEqualTo(response, HttpStatus.OK);
-        assertStationNamesContainsExactly(response, stationNames);
+        assertThat(responses)
+                .extracting(StationResponse::getName)
+                .hasSameElementsAs(names);
     }
 
     /**
@@ -97,110 +70,21 @@ class StationAcceptanceTest {
     void deleteStation() {
         final String name = "강남역";
 
-        // required
-        requiredStationsNotExist(name);
-
         // given
-        createStation(name);
+        stationFixture.지하철역을_생성한다(name);
         final Long stationId = getStationId(name);
 
         // when
-        final ExtractableResponse<Response> response = deleteStation(stationId);
+        stationFixture.지하철역을_제거한다(stationId);
 
         // then
-        assertStatusCodeEqualTo(response, HttpStatus.NO_CONTENT);
-        assertStationsEmpty();
-    }
-
-    private ExtractableResponse<Response> deleteStation(final Long stationId) {
-        return RestAssured.given().log().all()
-                .when().delete("/stations/" + stationId)
-                .then()
-                .extract();
+        assertThat(stationFixture.모든_지하철역을_조회한다()).isEmpty();
     }
 
     private Long getStationId(final String name) {
-        final List<StationResponse> responses =
-                RestAssured.given().log().all()
-                        .when().get(BASE_URL)
-                        .then()
-                        .extract()
-                        .jsonPath().getList(".", StationResponse.class);
+        final var station = stationFixture.지하철역을_조회한다(name);
+        assertThat(station).isPresent();
 
-        assertThat(responses).hasSize(1);
-
-        final Optional<StationResponse> response = responses.stream()
-                .filter(it -> it.getName().equals(name))
-                .findAny();
-
-        assertThat(response).isNotNull();
-
-        return response.get().getId();
-    }
-
-
-    private ExtractableResponse<Response> getAllStations() {
-        return RestAssured.given().log().all()
-                .when().get(BASE_URL)
-                .then()
-                .extract();
-    }
-
-    private void assertStationNamesContainsExactly(
-            final ExtractableResponse<Response> response,
-            final List<String> expectedNames
-    ) {
-        final List<String> actualNames = response.jsonPath().getList("name", String.class);
-        assertThat(actualNames).isEqualTo(expectedNames);
-    }
-
-    private void assertStationsEmpty() {
-        final List<StationResponse> stations =
-                RestAssured.given().log().all()
-                        .when().get(BASE_URL)
-                        .then()
-                        .extract()
-                        .jsonPath().getList(".", StationResponse.class);
-
-        assertThat(stations).isEmpty();
-    }
-
-    private void requiredStationsNotExist(final List<String> expectedNames) {
-        final List<String> actualNames =
-                RestAssured.given().log().all()
-                        .when().get(BASE_URL)
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-
-        if (!actualNames.isEmpty()) {
-            assertThat(actualNames).doesNotContainSequence(expectedNames);
-        }
-    }
-
-    private void requiredStationsNotExist(final String... expectedNames) {
-        requiredStationsNotExist(List.of(expectedNames));
-    }
-
-    private ExtractableResponse<Response> createStation(final String name) {
-        return RestAssured.given().log().all()
-                .body(Map.of("name", name))
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post(BASE_URL)
-                .then().log().all()
-                .extract();
-    }
-
-    private void assertStationCreated(final String expectedName) {
-        final List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get(BASE_URL)
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-
-        assertThat(stationNames).containsAnyOf(expectedName);
-    }
-
-    private void assertStatusCodeEqualTo(ExtractableResponse<Response> response, HttpStatus expected) {
-        assertThat(response.statusCode()).isEqualTo(expected.value());
+        return station.get().getId();
     }
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -1,23 +1,40 @@
 package subway;
 
-import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class StationAcceptanceTest {
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+class StationAcceptanceTest {
+
+    private static final String BASE_URL = "/stations";
+
+    @LocalServerPort
+    int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다
@@ -26,28 +43,17 @@ public class StationAcceptanceTest {
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStation() {
+        final String name = "강남역";
+
+        // required
+        requiredStationsNotExist(name);
+
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        final ExtractableResponse<Response> response = createStation(name);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-
-        // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-        assertThat(stationNames).containsAnyOf("강남역");
+        assertStatusCodeEqualTo(response, HttpStatus.CREATED);
+        assertStationCreated(name);
     }
 
     /**
@@ -55,13 +61,146 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역 목록을 조회한다.")
+    @Test
+    void showStations() {
+        final List<String> stationNames = List.of("강남역", "역삼역", "선릉역");
+
+        // required
+        requiredStationsNotExist(stationNames);
+
+        // given
+        stationNames.forEach(name ->
+                RestAssured.given().log().all()
+                        .body(Map.of("name", name))
+                        .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when().post(BASE_URL)
+                        .then().log().all()
+                        .statusCode(HttpStatus.CREATED.value())
+        );
+
+        // when
+        final ExtractableResponse<Response> response = getAllStations();
+
+        // then
+        assertStatusCodeEqualTo(response, HttpStatus.OK);
+        assertStationNamesContainsExactly(response, stationNames);
+    }
 
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 제거한다.")
+    @Test
+    void deleteStation() {
+        final String name = "강남역";
 
+        // required
+        requiredStationsNotExist(name);
+
+        // given
+        createStation(name);
+        final Long stationId = getStationId(name);
+
+        // when
+        final ExtractableResponse<Response> response = deleteStation(stationId);
+
+        // then
+        assertStatusCodeEqualTo(response, HttpStatus.NO_CONTENT);
+        assertStationsEmpty();
+    }
+
+    private ExtractableResponse<Response> deleteStation(final Long stationId) {
+        return RestAssured.given().log().all()
+                .when().delete("/stations/" + stationId)
+                .then()
+                .extract();
+    }
+
+    private Long getStationId(final String name) {
+        final List<StationResponse> responses =
+                RestAssured.given().log().all()
+                        .when().get(BASE_URL)
+                        .then()
+                        .extract()
+                        .jsonPath().getList(".", StationResponse.class);
+
+        assertThat(responses).hasSize(1);
+
+        final Optional<StationResponse> response = responses.stream()
+                .filter(it -> it.getName().equals(name))
+                .findAny();
+
+        assertThat(response).isNotNull();
+
+        return response.get().getId();
+    }
+
+
+    private ExtractableResponse<Response> getAllStations() {
+        return RestAssured.given().log().all()
+                .when().get(BASE_URL)
+                .then()
+                .extract();
+    }
+
+    private void assertStationNamesContainsExactly(
+            final ExtractableResponse<Response> response,
+            final List<String> expectedNames
+    ) {
+        final List<String> actualNames = response.jsonPath().getList("name", String.class);
+        assertThat(actualNames).isEqualTo(expectedNames);
+    }
+
+    private void assertStationsEmpty() {
+        final List<StationResponse> stations =
+                RestAssured.given().log().all()
+                        .when().get(BASE_URL)
+                        .then()
+                        .extract()
+                        .jsonPath().getList(".", StationResponse.class);
+
+        assertThat(stations).isEmpty();
+    }
+
+    private void requiredStationsNotExist(final List<String> expectedNames) {
+        final List<String> actualNames =
+                RestAssured.given().log().all()
+                        .when().get(BASE_URL)
+                        .then().log().all()
+                        .extract().jsonPath().getList("name", String.class);
+
+        if (!actualNames.isEmpty()) {
+            assertThat(actualNames).doesNotContainSequence(expectedNames);
+        }
+    }
+
+    private void requiredStationsNotExist(final String... expectedNames) {
+        requiredStationsNotExist(List.of(expectedNames));
+    }
+
+    private ExtractableResponse<Response> createStation(final String name) {
+        return RestAssured.given().log().all()
+                .body(Map.of("name", name))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post(BASE_URL)
+                .then().log().all()
+                .extract();
+    }
+
+    private void assertStationCreated(final String expectedName) {
+        final List<String> stationNames =
+                RestAssured.given().log().all()
+                        .when().get(BASE_URL)
+                        .then().log().all()
+                        .extract().jsonPath().getList("name", String.class);
+
+        assertThat(stationNames).containsAnyOf(expectedName);
+    }
+
+    private void assertStatusCodeEqualTo(ExtractableResponse<Response> response, HttpStatus expected) {
+        assertThat(response.statusCode()).isEqualTo(expected.value());
+    }
 }

--- a/src/test/java/subway/fixture/AcceptanceTest.java
+++ b/src/test/java/subway/fixture/AcceptanceTest.java
@@ -1,0 +1,28 @@
+package subway.fixture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+
+import io.restassured.RestAssured;
+import io.restassured.filter.log.RequestLoggingFilter;
+import io.restassured.filter.log.ResponseLoggingFilter;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class AcceptanceTest {
+
+    private static final RequestLoggingFilter requestLoggingFilter = new RequestLoggingFilter();
+    private static final ResponseLoggingFilter responseLoggingFilter = new ResponseLoggingFilter();
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+        RestAssured.filters(requestLoggingFilter, responseLoggingFilter);
+    }
+}

--- a/src/test/java/subway/fixture/StationFixture.java
+++ b/src/test/java/subway/fixture/StationFixture.java
@@ -1,0 +1,61 @@
+package subway.fixture;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ValidatableResponse;
+import subway.StationResponse;
+
+public class StationFixture {
+
+    public static final String BASE_URL = "/stations";
+
+    public void 지하철역을_생성한다(final String name) {
+        final var response = RestAssured.given()
+                .body(Map.of("name", name))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post(BASE_URL)
+                .then();
+
+        statusCodeShouldBe(response, HttpStatus.CREATED);
+    }
+
+    public void 지하철역을_생성한다(final List<String> names) {
+        names.forEach(this::지하철역을_생성한다);
+    }
+
+    public List<StationResponse> 모든_지하철역을_조회한다() {
+        final var response = RestAssured.given()
+                .when().get(BASE_URL)
+                .then();
+
+        statusCodeShouldBe(response, HttpStatus.OK);
+
+        return response.extract()
+                .jsonPath()
+                .getList("", StationResponse.class);
+    }
+
+    public Optional<StationResponse> 지하철역을_조회한다(final String name) {
+        return 모든_지하철역을_조회한다().stream()
+                .filter(it -> it.getName().equals(name))
+                .findAny();
+    }
+
+    public void 지하철역을_제거한다(final Long stationId) {
+        final var response = RestAssured.given()
+                .when().delete(BASE_URL + "/" + stationId)
+                .then();
+
+        statusCodeShouldBe(response, HttpStatus.NO_CONTENT);
+    }
+
+    private void statusCodeShouldBe(final ValidatableResponse response, final HttpStatus expected) {
+        response.statusCode(expected.value());
+    }
+}


### PR DESCRIPTION
안녕하세요!! 첫 미션 시작이네요 두근두근

이번 1단계에서 제시된 요구사항에 맞춰 인수 테스트를 작성하면서, 가독성 및 유지보수성을 고려하며 리팩토링을 가미해봤습니다. 잘 부탁드려요~

1. 테스트 격리) `DirtiesContext`와 in-memory h2를 활용하여 매 테스트마다 DB가 초기화되도록 했습니다.

1. 리팩토링) `StationAcceptanceTest`에서 시나리오에만 집중할 수 있도록 인수테스트에 대한 설정을 분리하고 싶었습니다. 그래서 `AcceptanceTest` 클래스를 만들어 `StationAcceptanceTest`가 이를 상속했습니다.

4. 리팩토링) RestAssured 로직이 여러줄을 차지하면서 가독성을 저하한다고 판단했습니다. 그래서 Station에 대한 RestAssured 행위를 `StationFixture`로 클래스 분리했습니다.