### PR TITLE
🚀 [1단계] 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -6,8 +6,10 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -17,14 +19,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Import(TestDatabaseCleaner.class)
 class StationAcceptanceTest {
 
     @LocalServerPort
     private int port;
 
+    @Autowired
+    private TestDatabaseCleaner dbCleaner;
+
+
     @BeforeEach
     void setUp() {
         RestAssured.port = port;
+        dbCleaner.cleanUpStation();
     }
 
     /**
@@ -81,7 +89,7 @@ class StationAcceptanceTest {
                 .extract();
     }
 
-    private ExtractableResponse<Response> 지하철_목록_조회(){
+    private ExtractableResponse<Response> 지하철_목록_조회() {
         return RestAssured.given().log().all()
                 .when().get("/stations")
                 .then().log().all()

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -78,7 +78,19 @@ class StationAcceptanceTest {
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 생성한 후 삭제하면 목록 조회시 해당 역이 조회되지 않는다.")
+    @Test
+    void create_and_deleteStation() {
+        // given
+        ExtractableResponse<Response> response = 지하철_생성("우영우");
+
+        // when
+        지하철_삭제(response.jsonPath().getLong("id"));
+
+        // then
+        List<String> stationNames = 지하철_목록_조회().jsonPath().getList("name", String.class);
+        assertThat(stationNames).doesNotContain("우영우");
+    }
 
     private ExtractableResponse<Response> 지하철_생성(String name){
         return RestAssured.given().log().all()
@@ -92,6 +104,14 @@ class StationAcceptanceTest {
     private ExtractableResponse<Response> 지하철_목록_조회() {
         return RestAssured.given().log().all()
                 .when().get("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 지하철_삭제(Long id){
+        return RestAssured.given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().delete("/stations/{id}", id)
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -3,50 +3,46 @@ package subway;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class StationAcceptanceTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class StationAcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+    }
+
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다
      * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
      */
-    @DisplayName("지하철역을 생성한다.")
+    @DisplayName("지하철역을 1개 생성하면 목록 조회시 생성한 1개의 역이 조회된다.")
     @Test
-    void createStation() {
+    void createOneStation() {
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = 지하철_생성("강남역");
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
+        List<String> stationNames = 지하철_목록_조회().jsonPath().getList("name", String.class);
         assertThat(stationNames).containsAnyOf("강남역");
     }
 
@@ -55,8 +51,20 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 2개 생성하면 목록 조회시 생성한 2개의 역이 조회된다.")
+    @Test
+    void createTwoStation() {
+        // given
+        지하철_생성("별똥별");
+        지하철_생성("역삼역");
 
+        // when
+        List<String> stationNames = 지하철_목록_조회().jsonPath().getList("name", String.class);
+
+        // then
+        assertThat(stationNames.size()).isEqualTo(2);
+        assertThat(stationNames).containsExactly("별똥별", "역삼역");
+    }
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면
@@ -64,4 +72,19 @@ public class StationAcceptanceTest {
      */
     // TODO: 지하철역 제거 인수 테스트 메서드 생성
 
+    private ExtractableResponse<Response> 지하철_생성(String name){
+        return RestAssured.given().log().all()
+                .body(Collections.singletonMap("name", name))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    private ExtractableResponse<Response> 지하철_목록_조회(){
+        return RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract();
+    }
 }

--- a/src/test/java/subway/TestDatabaseCleaner.java
+++ b/src/test/java/subway/TestDatabaseCleaner.java
@@ -1,0 +1,21 @@
+package subway;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.jdbc.JdbcTestUtils;
+
+/**
+ * @see <a href="https://www.baeldung.com/spring-tests#7-state-management">참고</a>
+ */
+@TestComponent
+public class TestDatabaseCleaner {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    public void cleanUpStation() {
+        JdbcTestUtils.deleteFromTables(jdbcTemplate, "station");
+        jdbcTemplate.update("ALTER TABLE station ALTER COLUMN id RESTART WITH 1");
+    }
+}


### PR DESCRIPTION
안녕하세요 리뷰어님~
이번 미션에서 테스트 네이밍 관련해서 의견을 여쭙고자 일부러 혼종스러운(?) 네이밍으로 테스트 이름을 지어보았습니다.
`테스트 목적`(조회테스트, 삭제테스트) 
`동작`(생성, 삭제이고 조회는X) 
`조회결과`
로 나눠서 의견주시면 감사드리겠습니다!

1. 동작을 실행하는 메소드는 한글 네이밍으로 분리
 -> 요건 강의때 한글네이밍 + 분리하자고 의견주셨어서요.

2. 테스트의 메소드명/displayName은 테스트하는데 행해지는 `동작`들 혹은 `동작 후 조회결과`를 설명
 -> 메소드명은 `동작_동작`로 지어보았습니다.
 -> displayName은 `동작`과 `조회 결과`를 모두 설명하게 지어보았습니다.

2번에 대해서 의견을 여쭙고 싶습니다. 🙇‍♀️🙇‍♀️
'2개의 지하철역을 조회'하는건 사실 목록을 조회할수 있는지가 `테스트 목적`인데, `동작`은 given을 위한 2개의 지하철역을 생성하고있어서요.
`테스트 목적` `동작` `조회결과` 세 가지 중에서 어떤 방식으로 조합해서 네이밍하는게 좀 더 적절하다고 생각하시나요?
(+ 업무코드에선 `조건`까지 껴서 `동작` `조건` `조회결과` 로 만들곤 합니다 🙇‍♀️)

그리고 테스트 DB 데이터 관리를 위해 https://www.baeldung.com/spring-tests#7-state-management 의 방법을 사용하였습니다. 🙇‍♀️
"station"이라는 테이블명을 하드코딩하고있어서 매우 아쉬운데... 테이블명에 의존적이지 않거나, 테이블명을 불러올 수 있으면 좋을것 같습니다 😅

이번 미션도 잘 부탁드리겠습니다!
감사합니다 :)