### PR TITLE
🚀 1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -9,7 +9,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -34,7 +33,7 @@ public class StationAcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        List<String> stationNames = 지하철역_목록을_조회한다();
+        List<String> stationNames = 지하철역_목록_이름을_조회한다();
 
         assertThat(stationNames).containsAnyOf(강남역);
     }
@@ -66,14 +65,14 @@ public class StationAcceptanceTest {
         지정된_이름의_지하철역을_생성한다(여의도역);
 
         //when
-        List<String> stationNames = 지하철역_목록을_조회한다();
+        List<String> stationNames = 지하철역_목록_이름을_조회한다();
 
         //then
         assertThat(stationNames).hasSize(2);
         assertThat(stationNames).contains(가양역, 여의도역);
     }
 
-    private List<String> 지하철역_목록을_조회한다() {
+    private List<String> 지하철역_목록_이름을_조회한다() {
         return RestAssured.given().log().all()
                 .when().get("/stations")
                 .then().log().all()
@@ -89,11 +88,42 @@ public class StationAcceptanceTest {
                 .when().post("/stations")
                 .then().log().all();
     }
+
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역 제거")
+    @Test
+    void deleteStationById() {
+        //given
+        String 가양역 = "가양역";
+        지정된_이름의_지하철역을_생성한다(가양역);
 
+        List<Long> stationIds = 지하철역_목록_Id를_조회한다();
+        Long stationId = stationIds.get(0);
+
+        //when
+        지하철역을_삭제한다(stationId);
+
+        //then
+        List<Long> stationIdsAfterDelete = 지하철역_목록_Id를_조회한다();
+
+        assertThat(stationIdsAfterDelete).hasSize(0);
+    }
+
+    private List<Long> 지하철역_목록_Id를_조회한다() {
+        return RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("id", Long.class);
+    }
+
+    private void 지하철역을_삭제한다(Long stationId) {
+        RestAssured.given().log().all()
+                .pathParam("id", stationId)
+                .when().delete("/stations/{id}")
+                .then().log().all();
+    }
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -27,27 +27,27 @@ public class StationAcceptanceTest {
     @Test
     void createStation() {
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        String 강남역 = "강남역";
+        ExtractableResponse<Response> response = 지정된_이름의_지하철역을_생성하고_응답결과를_받아온다(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-        assertThat(stationNames).containsAnyOf("강남역");
+        List<String> stationNames = 지하철역_목록을_조회한다();
+
+        assertThat(stationNames).containsAnyOf(강남역);
+    }
+
+    private ExtractableResponse<Response> 지정된_이름의_지하철역을_생성하고_응답결과를_받아온다(String stationName) {
+        Map<String, String> params = Map.of("name", stationName);
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
     }
 
     /**
@@ -82,6 +82,7 @@ public class StationAcceptanceTest {
 
     private void 지정된_이름의_지하철역을_생성한다(String stationName) {
         Map<String, String> params = Map.of("name", stationName);
+
         RestAssured.given().log().all()
                 .body(params)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -55,8 +55,39 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역 목록 조회")
+    @Test
+    void findAllStations() {
+        //given
+        String 가양역 = "가양역";
+        지정된_이름의_지하철역을_생성한다(가양역);
 
+        String 여의도역 = "여의도역";
+        지정된_이름의_지하철역을_생성한다(여의도역);
+
+        //when
+        List<String> stationNames = 지하철역_목록을_조회한다();
+
+        //then
+        assertThat(stationNames).hasSize(2);
+        assertThat(stationNames).contains(가양역, 여의도역);
+    }
+
+    private List<String> 지하철역_목록을_조회한다() {
+        return RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+    }
+
+    private void 지정된_이름의_지하철역을_생성한다(String stationName) {
+        Map<String, String> params = Map.of("name", stationName);
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all();
+    }
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -94,7 +94,7 @@ public class StationAcceptanceTest {
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    @DisplayName("지하철역 제거")
+    @DisplayName("지하철역 삭제")
     @Test
     void deleteStationById() {
         //given
@@ -105,9 +105,11 @@ public class StationAcceptanceTest {
         Long stationId = stationIds.get(0);
 
         //when
-        지하철역을_삭제한다(stationId);
+        ExtractableResponse<Response> response = 지하철역을_삭제한다(stationId);
 
         //then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
         List<Long> stationIdsAfterDelete = 지하철역_목록_Id를_조회한다();
 
         assertThat(stationIdsAfterDelete).hasSize(0);
@@ -120,10 +122,11 @@ public class StationAcceptanceTest {
                 .extract().jsonPath().getList("id", Long.class);
     }
 
-    private void 지하철역을_삭제한다(Long stationId) {
-        RestAssured.given().log().all()
+    private ExtractableResponse<Response> 지하철역을_삭제한다(Long stationId) {
+        return RestAssured.given().log().all()
                 .pathParam("id", stationId)
                 .when().delete("/stations/{id}")
-                .then().log().all();
+                .then().log().all()
+                .extract();
     }
 }


### PR DESCRIPTION
## 고민되는 부분 
`지하철역_목록_이름을_조회한다()` 메서드와 `지하철역_목록_Id를_조회한다()`라는 두 메서드가 각각 Json의 "name"필드와 "id"필드를 조회하는 것 말고는 다른 점이 없습니다. 이런 경우에 중복을 제거하는 방향으로 메서드를 작성하는게 더 좋을까요? 아니면 각 목적에 맞게 따로 구현하는 것이 더 좋을까요? 

원래는 메서드를 분리하지 않고 테스트를 작성하는 편이었는데, 처음으로 분리를 시도하다 보니 이와 같은 고민이 생기네요 😅 

정답은 없겠지만, 리뷰어님의 생각이 궁금합니다..! 


```java
// 지하철역_목록_이름을_조회한다()
private List<String> 지하철역_목록_이름을_조회한다() {
    return RestAssured.given().log().all()
            .when().get("/stations")
            .then().log().all()
            .extract().jsonPath().getList("name", String.class);
}

//  지하철역_목록_Id를_조회한다()
private List<Long> 지하철역_목록_Id를_조회한다() {
    return RestAssured.given().log().all()
            .when().get("/stations")
            .then().log().all()
            .extract().jsonPath().getList("id", Long.class);
}
```