### PR TITLE
🚀 1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/main/java/subway/controller/ApiRequestBody.java
+++ b/src/main/java/subway/controller/ApiRequestBody.java
@@ -1,0 +1,4 @@
+package subway.controller;
+
+public @interface ApiRequestBody {
+}

--- a/src/main/java/subway/controller/StationController.java
+++ b/src/main/java/subway/controller/StationController.java
@@ -28,6 +28,11 @@ public class StationController {
         return ResponseEntity.ok().body(stationService.findAllStations());
     }
 
+    @GetMapping(value = "/stations/{id}")
+    public ResponseEntity<StationResponse> showStation(@PathVariable Long id) {
+        return ResponseEntity.ok().body(stationService.findStation(id));
+    }
+
     @DeleteMapping("/stations/{id}")
     public ResponseEntity<Void> deleteStation(@PathVariable Long id) {
         stationService.deleteStationById(id);

--- a/src/main/java/subway/controller/StationController.java
+++ b/src/main/java/subway/controller/StationController.java
@@ -1,7 +1,10 @@
-package subway;
+package subway.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import subway.controller.request.StationRequest;
+import subway.controller.resonse.StationResponse;
+import subway.service.StationService;
 
 import java.net.URI;
 import java.util.List;

--- a/src/main/java/subway/controller/StationController.java
+++ b/src/main/java/subway/controller/StationController.java
@@ -38,4 +38,9 @@ public class StationController {
         stationService.deleteStationById(id);
         return ResponseEntity.noContent().build();
     }
+
+    @ExceptionHandler(value = {RuntimeException.class})
+    public ResponseEntity<Void> notFound(Exception ex) {
+        return ResponseEntity.notFound().build();
+    }
 }

--- a/src/main/java/subway/controller/request/StationRequest.java
+++ b/src/main/java/subway/controller/request/StationRequest.java
@@ -1,5 +1,8 @@
 package subway.controller.request;
 
+import subway.controller.ApiRequestBody;
+
+@ApiRequestBody
 public class StationRequest {
     private String name;
 

--- a/src/main/java/subway/controller/request/StationRequest.java
+++ b/src/main/java/subway/controller/request/StationRequest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.controller.request;
 
 public class StationRequest {
     private String name;

--- a/src/main/java/subway/controller/resonse/StationResponse.java
+++ b/src/main/java/subway/controller/resonse/StationResponse.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.controller.resonse;
 
 public class StationResponse {
     private Long id;

--- a/src/main/java/subway/domain/Station.java
+++ b/src/main/java/subway/domain/Station.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.domain;
 
 import javax.persistence.*;
 

--- a/src/main/java/subway/repository/StationRepository.java
+++ b/src/main/java/subway/repository/StationRepository.java
@@ -1,6 +1,7 @@
-package subway;
+package subway.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import subway.domain.Station;
 
 public interface StationRepository extends JpaRepository<Station, Long> {
 }

--- a/src/main/java/subway/service/StationService.java
+++ b/src/main/java/subway/service/StationService.java
@@ -1,7 +1,11 @@
-package subway;
+package subway.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import subway.controller.request.StationRequest;
+import subway.controller.resonse.StationResponse;
+import subway.domain.Station;
+import subway.repository.StationRepository;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/subway/service/StationService.java
+++ b/src/main/java/subway/service/StationService.java
@@ -36,6 +36,12 @@ public class StationService {
         stationRepository.deleteById(id);
     }
 
+    public StationResponse findStation(Long id) {
+        Station station = stationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException(String.format("not found station : %d", id)));
+        return this.createStationResponse(station);
+    }
+
     private StationResponse createStationResponse(Station station) {
         return new StationResponse(
                 station.getId(),

--- a/src/test/java/subway/AcceptanceTest.java
+++ b/src/test/java/subway/AcceptanceTest.java
@@ -15,6 +15,7 @@ import java.lang.annotation.RetentionPolicy;
 @Import(AcceptanceTest.SetUpRestAssured.class)
 public @interface AcceptanceTest {
 
+
     @TestComponent
     class SetUpRestAssured implements ApplicationListener<ServletWebServerInitializedEvent> {
 

--- a/src/test/java/subway/AcceptanceTest.java
+++ b/src/test/java/subway/AcceptanceTest.java
@@ -1,0 +1,26 @@
+package subway;
+
+import io.restassured.RestAssured;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.boot.web.servlet.context.ServletWebServerInitializedEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(AcceptanceTest.SetUpRestAssured.class)
+public @interface AcceptanceTest {
+
+    @TestComponent
+    class SetUpRestAssured implements ApplicationListener<ServletWebServerInitializedEvent> {
+
+        @Override
+        public void onApplicationEvent(ServletWebServerInitializedEvent event) {
+            RestAssured.port = event.getWebServer().getPort();
+        }
+    }
+}

--- a/src/test/java/subway/AcceptanceTestBuilder.java
+++ b/src/test/java/subway/AcceptanceTestBuilder.java
@@ -1,0 +1,124 @@
+package subway;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import subway.controller.ApiRequestBody;
+
+import java.util.Map;
+
+
+public final class AcceptanceTestBuilder {
+
+    private static final ObjectMapper objectMapper;
+
+    static {
+        objectMapper = new ObjectMapper();
+        objectMapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+    }
+
+    private RequestSpecification requestSpecification;
+    private Response response;
+
+
+    private AcceptanceTestBuilder() {
+        this.requestSpecification = RestAssured.given().log().all();
+    }
+
+    private AcceptanceTestBuilder(String baseUrl) {
+        this.requestSpecification = RestAssured.given().baseUri(baseUrl).log().all();
+    }
+
+    public static AcceptanceTestBuilder given() {
+        return new AcceptanceTestBuilder();
+    }
+
+    public static AcceptanceTestBuilder given(String baseUrl) {
+        return new AcceptanceTestBuilder(baseUrl);
+    }
+
+    public <T extends ApiRequestBody> AcceptanceTestBuilder body(T requestBody) {
+        String jsonString = convertToJsonString(requestBody);
+        this.requestSpecification = this.requestSpecification.body(jsonString);
+        return this;
+    }
+
+    public <M extends Map> AcceptanceTestBuilder body(M params) {
+        this.requestSpecification = this.requestSpecification.body(params);
+        return this;
+    }
+
+    public AcceptanceTestBuilder when(HttpMethod httpMethod, String uri) {
+        this.requestSpecification = this.requestSpecification.when();
+        switch (httpMethod) {
+            case POST:
+                this.response = this.requestSpecification.post(uri);
+                break;
+            case PUT:
+                this.response = this.requestSpecification.put(uri);
+                break;
+            case PATCH:
+                this.response = this.requestSpecification.patch(uri);
+                break;
+            case GET:
+                this.response = this.requestSpecification.get(uri);
+                break;
+            case DELETE:
+                this.response = this.requestSpecification.delete(uri);
+                break;
+            default:
+                break;
+        }
+        return this;
+    }
+
+    public AcceptanceTestBuilder when(HttpMethod httpMethod) {
+        this.requestSpecification = this.requestSpecification.when();
+        switch (httpMethod) {
+            case POST:
+                this.response = this.requestSpecification.post();
+                break;
+            case PUT:
+                this.response = this.requestSpecification.put();
+                break;
+            case PATCH:
+                this.response = this.requestSpecification.patch();
+                break;
+            case GET:
+                this.response = this.requestSpecification.get();
+                break;
+            case DELETE:
+                this.response = this.requestSpecification.delete();
+                break;
+            default:
+                break;
+        }
+        return this;
+    }
+
+    public AcceptanceTestBuilder contentType(ContentType contentType) {
+        this.requestSpecification = requestSpecification.contentType(contentType);
+        return this;
+    }
+
+    public ValidatableResponse then(HttpStatus httpStatus) {
+        return this.response.then().log().all().assertThat().statusCode(httpStatus.value());
+    }
+
+
+    public static <T extends ApiRequestBody> String convertToJsonString(T requestBody) {
+        try {
+            return objectMapper.writeValueAsString(requestBody);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+}

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 @DisplayName("지하철역 관련 기능")
 @AcceptanceTest
@@ -33,20 +34,33 @@ class StationAcceptanceTest {
         ExtractableResponse<Response> 지하철역_생성_됨 = 지하철역_생성_됨(지하철역_생성);
 
         // then
-        AcceptanceTestBuilder 지하철역_단건_조회 = 지하철역_단건_조회(지하철역_생성_됨.header(HttpHeaders.LOCATION));
+        AcceptanceTestBuilder 지하철역_단건_조회 = 지하철역_조회(지하철역_생성_됨.header(HttpHeaders.LOCATION));
         ValidatableResponse 지하철역_조회_됨 = 지하철역_조회_됨(지하철역_단건_조회);
 
         지하철역_조회_됨
                 .body("name", equalTo(stationName));
     }
 
+    @DisplayName("지하철역을 전체 조회한다.")
+    @Test
+    void showStations() {
+        // given
+        String firstStationName = "언주역";
+        String secondStationName = "삼성역";
 
-    /**
-     * Given 2개의 지하철역을 생성하고
-     * When 지하철역 목록을 조회하면
-     * Then 2개의 지하철역을 응답 받는다
-     */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+        // when
+        지하철역_생성(firstStationName);
+        지하철역_생성(secondStationName);
+
+        // then
+        AcceptanceTestBuilder 지하철역_조회 = 지하철역_조회(RESOURCE_URL);
+        ValidatableResponse 지하철역_조회_됨 = 지하철역_조회_됨(지하철역_조회);
+
+        지하철역_조회_됨
+                .body("", hasSize(2))
+                .body("[0].name", equalTo(firstStationName))
+                .body("[1].name", equalTo(secondStationName));
+    }
 
     /**
      * Given 지하철역을 생성하고
@@ -54,6 +68,9 @@ class StationAcceptanceTest {
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
     // TODO: 지하철역 제거 인수 테스트 메서드 생성
+
+
+
     private AcceptanceTestBuilder 지하철역_생성(String stationName) {
         Map<String, String> params = new HashMap<>();
         params.put("name", stationName);
@@ -67,7 +84,7 @@ class StationAcceptanceTest {
         return acceptanceTestBuilder.then(HttpStatus.CREATED).extract();
     }
 
-    private AcceptanceTestBuilder 지하철역_단건_조회(String url) {
+    private AcceptanceTestBuilder 지하철역_조회(String url) {
         return AcceptanceTestBuilder
                 .given()
                 .when(HttpMethod.GET, url);

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -34,7 +34,7 @@ class StationAcceptanceTest {
         ExtractableResponse<Response> 지하철역_생성_됨 = 지하철역_생성_됨(지하철역_생성);
 
         // then
-        AcceptanceTestBuilder 지하철역_단건_조회 = 지하철역_조회(지하철역_생성_됨.header(HttpHeaders.LOCATION));
+        AcceptanceTestBuilder 지하철역_단건_조회 = 지하철역_조회(getLocation(지하철역_생성_됨));
         ValidatableResponse 지하철역_조회_됨 = 지하철역_조회_됨(지하철역_단건_조회);
 
         지하철역_조회_됨
@@ -62,14 +62,26 @@ class StationAcceptanceTest {
                 .body("[1].name", equalTo(secondStationName));
     }
 
-    /**
-     * Given 지하철역을 생성하고
-     * When 그 지하철역을 삭제하면
-     * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
-     */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 삭제한다.")
+    @Test
+    void deleteStation() {
+        // given
+        String stationName = "청담역";
 
+        // when
+        AcceptanceTestBuilder 지하철역_생성 = 지하철역_생성(stationName);
+        ExtractableResponse<Response> 지하철역_생성_됨 = 지하철역_생성_됨(지하철역_생성);
+        String createdResourceLocation = getLocation(지하철역_생성_됨);
 
+        // then
+        AcceptanceTestBuilder 지하철역_제거 = 지하철역_제거(createdResourceLocation);
+        ValidatableResponse 지하철역_제거_됨 = 지하철역_제거_됨(지하철역_제거);
+
+        지하철역_제거_됨.noRootPath();
+
+        AcceptanceTestBuilder 지하철역_조회 = 지하철역_조회(createdResourceLocation);
+        지하철역을_찾지_못함(지하철역_조회);
+    }
 
     private AcceptanceTestBuilder 지하철역_생성(String stationName) {
         Map<String, String> params = new HashMap<>();
@@ -92,5 +104,23 @@ class StationAcceptanceTest {
 
     private ValidatableResponse 지하철역_조회_됨(AcceptanceTestBuilder acceptanceTestBuilder) {
         return acceptanceTestBuilder.then(HttpStatus.OK);
+    }
+
+    private AcceptanceTestBuilder 지하철역_제거(String url) {
+        return AcceptanceTestBuilder
+                .given()
+                .when(HttpMethod.DELETE, url);
+    }
+
+    private ValidatableResponse 지하철역_제거_됨(AcceptanceTestBuilder acceptanceTestBuilder) {
+        return acceptanceTestBuilder.then(HttpStatus.NO_CONTENT);
+    }
+
+    private void 지하철역을_찾지_못함(AcceptanceTestBuilder 지하철역_조회) {
+        지하철역_조회.then(HttpStatus.NOT_FOUND);
+    }
+
+    private String getLocation(ExtractableResponse<Response> response) {
+        return response.header(HttpHeaders.LOCATION);
     }
 }


### PR DESCRIPTION
### 요구 사항
- [x] 지하철역 인수 테스트를 완성하세요.
- [x] 지하철역 목록 조회 인수 테스트 작성하기
- [x] 지하철역 삭제 인수 테스트 작성하기

- 인수 테스트를 더 간결하고 수월하게 사용하기 위한 설정들을 추가했습니다.
- AcceptanceTestBuilder의 경우 각 요청에 따라 MultiTypeBuilder로 적용하여 요청 별 체이닝을 제한하면 좋겠지만 학습의 목적에서 벗어나기 때문에 하지 않았습니다.
- 전체 테스트가 실패하더라도 인수 테스트 리팩터링에 집중하라는 1단계 요구사항에 따라 데이터 초기화 작업을 따로 하지는 않았습니다.
```
각각의 테스트를 동작시키면 잘 동작하지만 한번에 동작시키면 실패할 수 있습니다. 
이번 단계에서는 이 부분에 대해 고려하지 말고 각각의 인수 테스트를 작성하는 것에 집중해서 진행하세요.
```