### PR TITLE
E2e step1

### DIFF
--- a/src/test/java/subway/HttpRequest.java
+++ b/src/test/java/subway/HttpRequest.java
@@ -1,0 +1,33 @@
+package subway;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class HttpRequest {
+    public static ExtractableResponse<Response> sendPostRequest(String path, Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post(path)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> sendDeleteRequest(String path) {
+        return RestAssured.given().log().all()
+                .when().delete(path)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> sendGetRequest(String path) {
+        return RestAssured.given().log().all()
+                .when().get(path)
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/subway/RestAssuredTest.java
+++ b/src/test/java/subway/RestAssuredTest.java
@@ -1,6 +1,5 @@
 package subway;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -12,14 +11,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class RestAssuredTest {
-
     @DisplayName("구글 페이지 접근 테스트")
     @Test
     void accessGoogle() {
-        // TODO: 구글 페이지 요청 구현
-        ExtractableResponse<Response> response = RestAssured.get("https://www.google.com")
-                .then()
-                .extract();
+        ExtractableResponse<Response> response = HttpRequest.sendGetRequest("https://www.google.com");
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -1,13 +1,11 @@
 package subway;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.HashMap;
 import java.util.List;
@@ -18,6 +16,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class StationAcceptanceTest {
+    private final String STATION_API_PATH = "/stations";
+    private final String STATION_GANGNAM = "강남역";
+    private final String STATION_SAMSUNG = "삼성역";
+    private final String PARAM_NAME = "name";
+    private final String PARAM_ID = "id";
+
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다
@@ -26,28 +30,12 @@ public class StationAcceptanceTest {
     @DisplayName("지하철역을 생성한다.")
     @Test
     void createStation() {
-        // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        // when & then
+        지하철역_생성(STATION_GANGNAM);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-
-        // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-        assertThat(stationNames).containsAnyOf("강남역");
+        List<String> stationNames = getJsonPathList(지하철역_목록_조회(), PARAM_NAME);
+        assertThat(stationNames).containsAnyOf(STATION_GANGNAM);
     }
 
     /**
@@ -55,13 +43,66 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역 목록을 조회한다.")
+    @Test
+    void getStationList() {
+        // given
+        지하철역_생성(STATION_GANGNAM);
+        지하철역_생성(STATION_SAMSUNG);
+
+        // when
+        List<String> stationNames = getJsonPathList(지하철역_목록_조회(), PARAM_NAME);
+
+        // then
+        assertThat(stationNames).containsOnly(STATION_GANGNAM, STATION_SAMSUNG);
+    }
 
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 삭제한다.")
+    @Test
+    void deleteStation() {
+        // given
+        long stationId = 지하철역_생성(STATION_GANGNAM).jsonPath().getLong(PARAM_ID);
 
+        // when
+        지하철역_삭제(stationId);
+
+        // then
+        List<String> stationNames = getJsonPathList(지하철역_목록_조회(), PARAM_NAME);
+        assertThat(stationNames).doesNotContainAnyElementsOf(List.of(STATION_GANGNAM));
+    }
+
+    private ExtractableResponse<Response> 지하철역_생성(String name) {
+        Map<String, String> params = generateStationParams(name);
+        ExtractableResponse<Response> response = HttpRequest.sendPostRequest(STATION_API_PATH, params);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        return response;
+    }
+
+    private ExtractableResponse<Response> 지하철역_목록_조회() {
+        ExtractableResponse<Response> response = HttpRequest.sendGetRequest(STATION_API_PATH);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        return response;
+    }
+
+    private void 지하철역_삭제(long stationId) {
+        ExtractableResponse<Response> response = HttpRequest.sendDeleteRequest(STATION_API_PATH + "/" + stationId);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    private Map<String, String> generateStationParams(String name) {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, name);
+        return params;
+    }
+
+    private List<String> getJsonPathList(ExtractableResponse<Response> response, String path) {
+        return response.jsonPath().getList(path, String.class);
+    }
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -20,7 +20,7 @@ public class StationAcceptanceTest {
     private final String STATION_GANGNAM = "강남역";
     private final String STATION_SAMSUNG = "삼성역";
     private final String PARAM_NAME = "name";
-    private final String PARAM_ID = "id";
+    private final String PARAM_STATION_ID = "id";
 
     /**
      * When 지하철역을 생성하면
@@ -29,7 +29,7 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 생성한다.")
     @Test
-    void createStation() {
+    void 지하철역_생성_테스트() {
         // when & then
         지하철역_생성(STATION_GANGNAM);
 
@@ -45,7 +45,7 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역 목록을 조회한다.")
     @Test
-    void getStationList() {
+    void 지하철역_목록_조회_테스트() {
         // given
         지하철역_생성(STATION_GANGNAM);
         지하철역_생성(STATION_SAMSUNG);
@@ -64,9 +64,9 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 삭제한다.")
     @Test
-    void deleteStation() {
+    void 지하철역_삭제_테스트() {
         // given
-        long stationId = 지하철역_생성(STATION_GANGNAM).jsonPath().getLong(PARAM_ID);
+        long stationId = 지하철역_생성(STATION_GANGNAM).jsonPath().getLong(PARAM_STATION_ID);
 
         // when
         지하철역_삭제(stationId);


### PR DESCRIPTION
### 요구사항

1. 지하철역 목록 조회 인수 테스트 작성하기
2. 지하철역 삭제 인수 테스트 작성하기
3. 인수 테스트의 재사용성과 가독성, 그리고 빠른 테스트 의도 파악을 위해 인수 테스트를 리팩터링

### 추가사항

1. StationAcceptanceTest 뿐만 아니라 subway 내 모든 테스트에서 공통적으로 사용될 RestAssured Request를 추상화해 HttpRequest 모듈로 분리, 각 테스트 클래스에서 RestAssured 의존성 제거
2. 가독성 향상을 위한 메서드 명 한글화 