### PR TITLE
1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -18,6 +18,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class StationAcceptanceTest {
+
+    private final String CREATE_STATION_API_URL = "/stations";
+    private final String SHOW_STATIONS_API_URL = "/stations";
+
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다
@@ -27,15 +31,23 @@ public class StationAcceptanceTest {
     @Test
     void createStation() {
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
+        Map<String, String> parameter = new HashMap<>();
+        String defaultStationName = "강남역";
+
+        parameter.put("name", defaultStationName);
 
         ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
+                RestAssured
+                        .given()
+                            .log()
+                                .all()
+                            .body(parameter)
+                            .contentType(MediaType.APPLICATION_JSON_VALUE)
+                        .when()
+                            .post(CREATE_STATION_API_URL)
+                        .then()
+                            .log()
+                                .all()
                         .extract();
 
         // then
@@ -43,11 +55,20 @@ public class StationAcceptanceTest {
 
         // then
         List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-        assertThat(stationNames).containsAnyOf("강남역");
+                RestAssured
+                        .given()
+                            .log()
+                                .all()
+                        .when()
+                            .get(SHOW_STATIONS_API_URL)
+                        .then()
+                            .log()
+                                .all()
+                        .extract()
+                            .jsonPath()
+                                .getList("name", String.class);
+
+        assertThat(stationNames).containsAnyOf(defaultStationName);
     }
 
     /**
@@ -56,6 +77,10 @@ public class StationAcceptanceTest {
      * Then 2개의 지하철역을 응답 받는다
      */
     // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역 목록을 조회한다.")
+    @Test
+    void showStations() {
+    }
 
     /**
      * Given 지하철역을 생성하고
@@ -63,5 +88,4 @@ public class StationAcceptanceTest {
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
     // TODO: 지하철역 제거 인수 테스트 메서드 생성
-
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -3,15 +3,17 @@ package subway;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,19 +24,23 @@ public class StationAcceptanceTest {
     private final String CREATE_STATION_API_URL = "/stations";
     private final String SHOW_STATIONS_API_URL = "/stations";
 
+    static Stream stationNames() {
+        return Stream.of("강남역");
+    }
+
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다
      * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
      */
     @DisplayName("지하철역을 생성한다.")
-    @Test
-    void createStation() {
+    @ParameterizedTest
+    @MethodSource("stationNames")
+    void createStation(String stationName) {
         // when
         Map<String, String> parameter = new HashMap<>();
-        String defaultStationName = "강남역";
 
-        parameter.put("name", defaultStationName);
+        parameter.put("name", stationName);
 
         ExtractableResponse<Response> response =
                 RestAssured
@@ -68,7 +74,7 @@ public class StationAcceptanceTest {
                             .jsonPath()
                                 .getList("name", String.class);
 
-        assertThat(stationNames).containsAnyOf(defaultStationName);
+        assertThat(stationNames).containsAnyOf(stationName);
     }
 
     /**
@@ -76,10 +82,31 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
     @DisplayName("지하철역 목록을 조회한다.")
     @Test
     void showStations() {
+        // given
+        List<String> stationNames = Arrays.asList("구디역", "봉천역");
+        for (String stationName : stationNames) {
+            createStation(stationName);
+        }
+
+        // when
+        List<String> response = RestAssured
+                        .given()
+                            .log()
+                                .all()
+                        .when()
+                            .get(SHOW_STATIONS_API_URL)
+                        .then()
+                            .log()
+                                .all()
+                        .extract()
+                            .jsonPath()
+                                .getList("name", String.class);
+
+        // then
+        Assertions.assertThat(response).contains("구디역", "봉천역");
     }
 
     /**

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -21,8 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class StationAcceptanceTest {
 
-    private final String CREATE_STATION_API_URL = "/stations";
-    private final String SHOW_STATIONS_API_URL = "/stations";
+    private final String STATION_API_URL = "/stations";
 
     static Stream stationNames() {
         return Stream.of("강남역");
@@ -39,7 +38,6 @@ public class StationAcceptanceTest {
     void createStation(String stationName) {
         // when
         Map<String, String> parameter = new HashMap<>();
-
         parameter.put("name", stationName);
 
         ExtractableResponse<Response> response =
@@ -50,7 +48,7 @@ public class StationAcceptanceTest {
                             .body(parameter)
                             .contentType(MediaType.APPLICATION_JSON_VALUE)
                         .when()
-                            .post(CREATE_STATION_API_URL)
+                            .post(STATION_API_URL)
                         .then()
                             .log()
                                 .all()
@@ -66,7 +64,7 @@ public class StationAcceptanceTest {
                             .log()
                                 .all()
                         .when()
-                            .get(SHOW_STATIONS_API_URL)
+                            .get(STATION_API_URL)
                         .then()
                             .log()
                                 .all()
@@ -97,7 +95,7 @@ public class StationAcceptanceTest {
                             .log()
                                 .all()
                         .when()
-                            .get(SHOW_STATIONS_API_URL)
+                            .get(STATION_API_URL)
                         .then()
                             .log()
                                 .all()
@@ -114,5 +112,43 @@ public class StationAcceptanceTest {
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철 역을 삭제한다.")
+    @Test
+    void deleteStation() {
+        // given
+        Map<String, String> parameter = new HashMap<>();
+        parameter.put("name", "봉천역");
+
+        String responseId = RestAssured
+                .given()
+                    .log()
+                        .all()
+                    .body(parameter)
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                    .log()
+                        .all()
+                    .post(STATION_API_URL)
+                .then()
+                    .log()
+                        .all()
+                    .extract()
+                        .jsonPath()
+                            .getString("id");
+
+        // when
+        ExtractableResponse<Response> response = RestAssured
+                .given()
+                    .log()
+                        .all()
+                .when()
+                    .log()
+                        .all()
+                    .delete(STATION_API_URL + "/" + responseId)
+                .then()
+                    .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
 }


### PR DESCRIPTION
1단계 지하철 역 인수 테스트를 구현하여 PR 드립니다.

제가 작성한 테스트 코드의 문제점은 중복 코드가 너무 많다고 생각합니다. 슬랙의 리뷰어 채널에서 말씀해주신 지하철 역을 생성하는 메서드를 추출할 경우 중복 코드의 문제점을 조금이나마 줄일 수 있다고 생각이 듭니다. 그러면 이때 테스트 코드를 위해 사용되는 지하철 역 생성 메서드는 "@Test"이 존재하지 않고 테스트를 진행하려는 지하철 역 생성 메서드와는 별도의 메서드로 생각을 하면 되는지 궁금합니다.

- ex) createStation(), createStationForTestCode()