### PR TITLE
🚀 2단계 - 지하철 노선 관리

### DIFF
--- a/src/main/java/subway/common/exception/BusinessException.java
+++ b/src/main/java/subway/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package subway.common.exception;
+
+public abstract class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public int getStatus() {
+        return errorCode.getStatus();
+    }
+}

--- a/src/main/java/subway/common/exception/BusinessExceptionHandler.java
+++ b/src/main/java/subway/common/exception/BusinessExceptionHandler.java
@@ -1,0 +1,15 @@
+package subway.common.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class BusinessExceptionHandler {
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResult> handleBusinessException(BusinessException businessException) {
+        return ResponseEntity
+                .status(businessException.getStatus())
+                .body(ErrorResult.from(businessException));
+    }
+}

--- a/src/main/java/subway/common/exception/ErrorCode.java
+++ b/src/main/java/subway/common/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package subway.common.exception;
+
+public enum ErrorCode {
+    STATION_NOT_FOUND_EXCEPTION(404, "없는 지하철역입니다."),
+    LINE_NOT_FOUND_EXCEPTION(404, "없는 지하철 노선입니다.")
+    ;
+
+    private final int status;
+    private final String message;
+
+    ErrorCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/subway/common/exception/ErrorResult.java
+++ b/src/main/java/subway/common/exception/ErrorResult.java
@@ -1,0 +1,23 @@
+package subway.common.exception;
+
+public class ErrorResult {
+    private final int status;
+    private final String message;
+
+    public static ErrorResult from(BusinessException businessException) {
+        return new ErrorResult(businessException.getStatus(), businessException.getMessage());
+    }
+
+    public ErrorResult(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public int getStatus() {
+        return status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/subway/line/application/LineService.java
+++ b/src/main/java/subway/line/application/LineService.java
@@ -60,4 +60,10 @@ public class LineService {
         Line line = getLine(id);
         line.update(lineUpdateRequest.getName(), lineUpdateRequest.getColor());
     }
+
+    @Transactional
+    public void deleteLine(Long id) {
+        Line line = getLine(id);
+        lineRepository.delete(line);
+    }
 }

--- a/src/main/java/subway/line/application/LineService.java
+++ b/src/main/java/subway/line/application/LineService.java
@@ -1,0 +1,39 @@
+package subway.line.application;
+
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import subway.line.domain.Line;
+import subway.line.domain.LineRepository;
+import subway.line.dto.LineRequest;
+import subway.line.dto.LineResponse;
+import subway.line.dto.StationOnLineResponse;
+import subway.station.domain.StationRepository;
+
+@Transactional(readOnly = true)
+@Service
+public class LineService {
+    private final LineRepository lineRepository;
+    private final StationRepository stationRepository;
+
+    public LineService(LineRepository lineRepository, StationRepository stationRepository) {
+        this.lineRepository = lineRepository;
+        this.stationRepository = stationRepository;
+    }
+
+    @Transactional
+    public LineResponse saveLine(LineRequest lineRequest) {
+        Line line = new Line(lineRequest.getName(), lineRequest.getColor(), lineRequest.getUpStationId(), lineRequest.getDownStationId(), lineRequest.getDistance());
+        lineRepository.save(line);
+
+        StationOnLineResponse upStation = stationRepository.findById(lineRequest.getUpStationId())
+                .map(station -> new StationOnLineResponse(station.getId(), station.getName()))
+                .orElseThrow(() -> new IllegalArgumentException("station이 없습니다. stationId=" + lineRequest.getUpStationId()));
+
+        StationOnLineResponse downStation = stationRepository.findById(lineRequest.getDownStationId())
+                .map(station -> new StationOnLineResponse(station.getId(), station.getName()))
+                .orElseThrow(() -> new IllegalArgumentException("station이 없습니다. stationId=" + lineRequest.getDownStationId()));
+
+        return new LineResponse(line.getId(), line.getName(), line.getColor(), List.of(upStation, downStation));
+    }
+}

--- a/src/main/java/subway/line/application/LineService.java
+++ b/src/main/java/subway/line/application/LineService.java
@@ -1,5 +1,7 @@
 package subway.line.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import subway.line.domain.Line;
@@ -34,6 +36,12 @@ public class LineService {
     private Station getStation(Long stationId) {
         return stationRepository.findById(stationId)
                 .orElseThrow(() -> new IllegalArgumentException("station이 없습니다. stationId=" + stationId));
+    }
+
+    public List<LineResponse> findAllStation() {
+        return lineRepository.findAll().stream()
+                .map(LineResponse::of)
+                .collect(Collectors.toList());
     }
 
     public LineResponse findStation(Long id) {

--- a/src/main/java/subway/line/application/LineService.java
+++ b/src/main/java/subway/line/application/LineService.java
@@ -31,8 +31,8 @@ public class LineService {
         return LineResponse.of(line);
     }
 
-    private Station getStation(Long lineRequest) {
-        return stationRepository.findById(lineRequest)
-                .orElseThrow(() -> new IllegalArgumentException("station이 없습니다. stationId=" + lineRequest));
+    private Station getStation(Long stationId) {
+        return stationRepository.findById(stationId)
+                .orElseThrow(() -> new IllegalArgumentException("station이 없습니다. stationId=" + stationId));
     }
 }

--- a/src/main/java/subway/line/application/LineService.java
+++ b/src/main/java/subway/line/application/LineService.java
@@ -35,4 +35,11 @@ public class LineService {
         return stationRepository.findById(stationId)
                 .orElseThrow(() -> new IllegalArgumentException("station이 없습니다. stationId=" + stationId));
     }
+
+    public LineResponse findStation(Long id) {
+        Line line = lineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("line이 없습니다. lineId=" + id));
+
+        return LineResponse.of(line);
+    }
 }

--- a/src/main/java/subway/line/application/LineService.java
+++ b/src/main/java/subway/line/application/LineService.java
@@ -9,8 +9,10 @@ import subway.line.domain.LineRepository;
 import subway.line.dto.LineCreateRequest;
 import subway.line.dto.LineResponse;
 import subway.line.dto.LineUpdateRequest;
+import subway.line.exception.LineNotFoundException;
 import subway.station.domain.Station;
 import subway.station.domain.StationRepository;
+import subway.station.exception.StationNotFoundException;
 
 @Transactional(readOnly = true)
 @Service
@@ -36,7 +38,7 @@ public class LineService {
 
     private Station getStation(Long stationId) {
         return stationRepository.findById(stationId)
-                .orElseThrow(() -> new IllegalArgumentException("station이 없습니다. stationId=" + stationId));
+                .orElseThrow(StationNotFoundException::new);
     }
 
     public List<LineResponse> findAllStation() {
@@ -52,7 +54,7 @@ public class LineService {
 
     private Line getLine(Long id) {
         return lineRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("line이 없습니다. lineId=" + id));
+                .orElseThrow(LineNotFoundException::new);
     }
 
     @Transactional

--- a/src/main/java/subway/line/application/LineService.java
+++ b/src/main/java/subway/line/application/LineService.java
@@ -6,8 +6,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import subway.line.domain.Line;
 import subway.line.domain.LineRepository;
-import subway.line.dto.LineRequest;
+import subway.line.dto.LineCreateRequest;
 import subway.line.dto.LineResponse;
+import subway.line.dto.LineUpdateRequest;
 import subway.station.domain.Station;
 import subway.station.domain.StationRepository;
 
@@ -23,11 +24,11 @@ public class LineService {
     }
 
     @Transactional
-    public LineResponse saveLine(LineRequest lineRequest) {
-        Station upStation = getStation(lineRequest.getUpStationId());
-        Station downStation = getStation(lineRequest.getDownStationId());
+    public LineResponse saveLine(LineCreateRequest lineCreateRequest) {
+        Station upStation = getStation(lineCreateRequest.getUpStationId());
+        Station downStation = getStation(lineCreateRequest.getDownStationId());
 
-        Line line = new Line(lineRequest.getName(), lineRequest.getColor(), upStation, downStation, lineRequest.getDistance());
+        Line line = new Line(lineCreateRequest.getName(), lineCreateRequest.getColor(), upStation, downStation, lineCreateRequest.getDistance());
         lineRepository.save(line);
 
         return LineResponse.of(line);
@@ -44,10 +45,19 @@ public class LineService {
                 .collect(Collectors.toList());
     }
 
-    public LineResponse findStation(Long id) {
-        Line line = lineRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("line이 없습니다. lineId=" + id));
-
+    public LineResponse findLine(Long id) {
+        Line line = getLine(id);
         return LineResponse.of(line);
+    }
+
+    private Line getLine(Long id) {
+        return lineRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("line이 없습니다. lineId=" + id));
+    }
+
+    @Transactional
+    public void updateLine(Long id, LineUpdateRequest lineUpdateRequest) {
+        Line line = getLine(id);
+        line.update(lineUpdateRequest.getName(), lineUpdateRequest.getColor());
     }
 }

--- a/src/main/java/subway/line/domain/Line.java
+++ b/src/main/java/subway/line/domain/Line.java
@@ -60,4 +60,10 @@ public class Line {
     public Integer getDistance() {
         return distance;
     }
+
+    //TODO null이 들어오면 어떻게 할지 고민 -> null일 경우 예외를 던질까?
+    public void update(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
 }

--- a/src/main/java/subway/line/domain/Line.java
+++ b/src/main/java/subway/line/domain/Line.java
@@ -1,29 +1,43 @@
 package subway.line.domain;
 
+import java.util.List;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import subway.station.domain.Station;
 
 @Entity
 public class Line {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
+
     private String color;
-    private Long upStationId;
-    private Long downStationId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "up_sation_id")
+    private Station upStation;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "down_sation_id")
+    private Station downStation;
+
     private Integer distance;
 
     protected Line() {
     }
 
-    public Line(String name, String color, Long upStationId, Long downStationId, Integer distance) {
+    public Line(String name, String color, Station upStation, Station downStation, Integer distance) {
         this.name = name;
         this.color = color;
-        this.upStationId = upStationId;
-        this.downStationId = downStationId;
+        this.upStation = upStation;
+        this.downStation = downStation;
         this.distance = distance;
     }
 
@@ -39,12 +53,8 @@ public class Line {
         return color;
     }
 
-    public Long getUpStationId() {
-        return upStationId;
-    }
-
-    public Long getDownStationId() {
-        return downStationId;
+    public List<Station> getStations() {
+        return List.of(upStation, downStation);
     }
 
     public Integer getDistance() {

--- a/src/main/java/subway/line/domain/Line.java
+++ b/src/main/java/subway/line/domain/Line.java
@@ -1,0 +1,53 @@
+package subway.line.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Line {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private Integer distance;
+
+    protected Line() {
+    }
+
+    public Line(String name, String color, Long upStationId, Long downStationId, Integer distance) {
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Integer getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/subway/line/domain/LineRepository.java
+++ b/src/main/java/subway/line/domain/LineRepository.java
@@ -1,0 +1,6 @@
+package subway.line.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineRepository extends JpaRepository<Line, Long> {
+}

--- a/src/main/java/subway/line/dto/LineCreateRequest.java
+++ b/src/main/java/subway/line/dto/LineCreateRequest.java
@@ -1,6 +1,6 @@
 package subway.line.dto;
 
-public class LineRequest {
+public class LineCreateRequest {
     private String name;
     private String color;
     private Long upStationId;

--- a/src/main/java/subway/line/dto/LineRequest.java
+++ b/src/main/java/subway/line/dto/LineRequest.java
@@ -6,4 +6,24 @@ public class LineRequest {
     private Long upStationId;
     private Long downStationId;
     private Integer distance;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public Long getUpStationId() {
+        return upStationId;
+    }
+
+    public Long getDownStationId() {
+        return downStationId;
+    }
+
+    public Integer getDistance() {
+        return distance;
+    }
 }

--- a/src/main/java/subway/line/dto/LineRequest.java
+++ b/src/main/java/subway/line/dto/LineRequest.java
@@ -1,0 +1,9 @@
+package subway.line.dto;
+
+public class LineRequest {
+    private String name;
+    private String color;
+    private Long upStationId;
+    private Long downStationId;
+    private Integer distance;
+}

--- a/src/main/java/subway/line/dto/LineResponse.java
+++ b/src/main/java/subway/line/dto/LineResponse.java
@@ -1,12 +1,27 @@
 package subway.line.dto;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import subway.line.domain.Line;
 
 public class LineResponse {
     private final Long id;
     private final String name;
     private final String color;
     private final List<StationOnLineResponse> stationResponses;
+
+    public static LineResponse of(Line line) {
+        List<StationOnLineResponse> stationOnLineResponses = line.getStations().stream()
+                .map(StationOnLineResponse::of)
+                .collect(Collectors.toList());
+
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor(),
+                stationOnLineResponses
+        );
+    }
 
     public LineResponse(Long id, String name, String color, List<StationOnLineResponse> stationResponses) {
         this.id = id;

--- a/src/main/java/subway/line/dto/LineResponse.java
+++ b/src/main/java/subway/line/dto/LineResponse.java
@@ -1,15 +1,14 @@
 package subway.line.dto;
 
 import java.util.List;
-import subway.station.dto.StationResponse;
 
 public class LineResponse {
     private final Long id;
     private final String name;
     private final String color;
-    private final List<StationResponse> stationResponses;
+    private final List<StationOnLineResponse> stationResponses;
 
-    public LineResponse(Long id, String name, String color, List<StationResponse> stationResponses) {
+    public LineResponse(Long id, String name, String color, List<StationOnLineResponse> stationResponses) {
         this.id = id;
         this.name = name;
         this.color = color;
@@ -18,5 +17,17 @@ public class LineResponse {
 
     public Long getId() {
         return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public List<StationOnLineResponse> getStationResponses() {
+        return stationResponses;
     }
 }

--- a/src/main/java/subway/line/dto/LineResponse.java
+++ b/src/main/java/subway/line/dto/LineResponse.java
@@ -1,0 +1,22 @@
+package subway.line.dto;
+
+import java.util.List;
+import subway.station.dto.StationResponse;
+
+public class LineResponse {
+    private final Long id;
+    private final String name;
+    private final String color;
+    private final List<StationResponse> stationResponses;
+
+    public LineResponse(Long id, String name, String color, List<StationResponse> stationResponses) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.stationResponses = stationResponses;
+    }
+
+    public Long getId() {
+        return id;
+    }
+}

--- a/src/main/java/subway/line/dto/LineResponse.java
+++ b/src/main/java/subway/line/dto/LineResponse.java
@@ -8,7 +8,7 @@ public class LineResponse {
     private final Long id;
     private final String name;
     private final String color;
-    private final List<StationOnLineResponse> stationResponses;
+    private final List<StationOnLineResponse> stations;
 
     public static LineResponse of(Line line) {
         List<StationOnLineResponse> stationOnLineResponses = line.getStations().stream()
@@ -23,11 +23,11 @@ public class LineResponse {
         );
     }
 
-    public LineResponse(Long id, String name, String color, List<StationOnLineResponse> stationResponses) {
+    public LineResponse(Long id, String name, String color, List<StationOnLineResponse> stations) {
         this.id = id;
         this.name = name;
         this.color = color;
-        this.stationResponses = stationResponses;
+        this.stations = stations;
     }
 
     public Long getId() {
@@ -42,7 +42,7 @@ public class LineResponse {
         return color;
     }
 
-    public List<StationOnLineResponse> getStationResponses() {
-        return stationResponses;
+    public List<StationOnLineResponse> getStations() {
+        return stations;
     }
 }

--- a/src/main/java/subway/line/dto/LineUpdateRequest.java
+++ b/src/main/java/subway/line/dto/LineUpdateRequest.java
@@ -1,0 +1,14 @@
+package subway.line.dto;
+
+public class LineUpdateRequest {
+    private String name;
+    private String color;
+
+    public String getName() {
+        return name;
+    }
+
+    public String getColor() {
+        return color;
+    }
+}

--- a/src/main/java/subway/line/dto/StationOnLineResponse.java
+++ b/src/main/java/subway/line/dto/StationOnLineResponse.java
@@ -1,8 +1,14 @@
 package subway.line.dto;
 
+import subway.station.domain.Station;
+
 public class StationOnLineResponse {
     private final Long id;
     private final String name;
+
+    public static StationOnLineResponse of(Station station) {
+        return new StationOnLineResponse(station.getId(), station.getName());
+    }
 
     public StationOnLineResponse(Long id, String name) {
         this.id = id;

--- a/src/main/java/subway/line/dto/StationOnLineResponse.java
+++ b/src/main/java/subway/line/dto/StationOnLineResponse.java
@@ -1,0 +1,19 @@
+package subway.line.dto;
+
+public class StationOnLineResponse {
+    private final Long id;
+    private final String name;
+
+    public StationOnLineResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/subway/line/exception/LineNotFoundException.java
+++ b/src/main/java/subway/line/exception/LineNotFoundException.java
@@ -1,0 +1,10 @@
+package subway.line.exception;
+
+import subway.common.exception.BusinessException;
+import subway.common.exception.ErrorCode;
+
+public class LineNotFoundException extends BusinessException {
+    public LineNotFoundException() {
+        super(ErrorCode.LINE_NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/subway/line/presentation/LineController.java
+++ b/src/main/java/subway/line/presentation/LineController.java
@@ -1,0 +1,24 @@
+package subway.line.presentation;
+
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import subway.line.dto.LineResponse;
+import subway.line.dto.LineRequest;
+
+@RestController
+public class LineController {
+    private final LineService lineService;
+
+    public LineController(LineService lineService) {
+        this.lineService = lineService;
+    }
+
+    @PostMapping("/lines")
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+        LineResponse lineResponse = lineService.saveLine(lineRequest);
+        return ResponseEntity.created(URI.create("/lines" + lineResponse.getId())).body(lineResponse);
+    }
+}

--- a/src/main/java/subway/line/presentation/LineController.java
+++ b/src/main/java/subway/line/presentation/LineController.java
@@ -3,6 +3,7 @@ package subway.line.presentation;
 import java.net.URI;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,5 +43,11 @@ public class LineController {
     public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineUpdateRequest lineUpdateRequest) {
         lineService.updateLine(id, lineUpdateRequest);
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/lines/{id}")
+    public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
+        lineService.deleteLine(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/subway/line/presentation/LineController.java
+++ b/src/main/java/subway/line/presentation/LineController.java
@@ -1,6 +1,7 @@
 package subway.line.presentation;
 
 import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,6 +24,11 @@ public class LineController {
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         LineResponse lineResponse = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + lineResponse.getId())).body(lineResponse);
+    }
+
+    @GetMapping("/lines")
+    public ResponseEntity<List<LineResponse>> showStations() {
+        return ResponseEntity.ok().body(lineService.findAllStation());
     }
 
     @GetMapping("/lines/{id}")

--- a/src/main/java/subway/line/presentation/LineController.java
+++ b/src/main/java/subway/line/presentation/LineController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import subway.line.application.LineService;
 import subway.line.dto.LineResponse;
 import subway.line.dto.LineRequest;
 
@@ -19,6 +20,6 @@ public class LineController {
     @PostMapping("/lines")
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         LineResponse lineResponse = lineService.saveLine(lineRequest);
-        return ResponseEntity.created(URI.create("/lines" + lineResponse.getId())).body(lineResponse);
+        return ResponseEntity.created(URI.create("/lines/" + lineResponse.getId())).body(lineResponse);
     }
 }

--- a/src/main/java/subway/line/presentation/LineController.java
+++ b/src/main/java/subway/line/presentation/LineController.java
@@ -27,12 +27,12 @@ public class LineController {
     }
 
     @GetMapping("/lines")
-    public ResponseEntity<List<LineResponse>> showStations() {
+    public ResponseEntity<List<LineResponse>> showLines() {
         return ResponseEntity.ok().body(lineService.findAllStation());
     }
 
     @GetMapping("/lines/{id}")
-    public ResponseEntity<LineResponse> showStation(@PathVariable Long id) {
+    public ResponseEntity<LineResponse> showLine(@PathVariable Long id) {
         return ResponseEntity.ok().body(lineService.findStation(id));
     }
 }

--- a/src/main/java/subway/line/presentation/LineController.java
+++ b/src/main/java/subway/line/presentation/LineController.java
@@ -6,11 +6,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 import subway.line.application.LineService;
 import subway.line.dto.LineResponse;
-import subway.line.dto.LineRequest;
+import subway.line.dto.LineCreateRequest;
+import subway.line.dto.LineUpdateRequest;
 
 @RestController
 public class LineController {
@@ -21,8 +23,8 @@ public class LineController {
     }
 
     @PostMapping("/lines")
-    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
-        LineResponse lineResponse = lineService.saveLine(lineRequest);
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineCreateRequest lineCreateRequest) {
+        LineResponse lineResponse = lineService.saveLine(lineCreateRequest);
         return ResponseEntity.created(URI.create("/lines/" + lineResponse.getId())).body(lineResponse);
     }
 
@@ -33,6 +35,12 @@ public class LineController {
 
     @GetMapping("/lines/{id}")
     public ResponseEntity<LineResponse> showLine(@PathVariable Long id) {
-        return ResponseEntity.ok().body(lineService.findStation(id));
+        return ResponseEntity.ok().body(lineService.findLine(id));
+    }
+
+    @PutMapping("/lines/{id}")
+    public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineUpdateRequest lineUpdateRequest) {
+        lineService.updateLine(id, lineUpdateRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/subway/line/presentation/LineController.java
+++ b/src/main/java/subway/line/presentation/LineController.java
@@ -2,6 +2,8 @@ package subway.line.presentation;
 
 import java.net.URI;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,5 +23,10 @@ public class LineController {
     public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         LineResponse lineResponse = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + lineResponse.getId())).body(lineResponse);
+    }
+
+    @GetMapping("/lines/{id}")
+    public ResponseEntity<LineResponse> showStation(@PathVariable Long id) {
+        return ResponseEntity.ok().body(lineService.findStation(id));
     }
 }

--- a/src/main/java/subway/station/application/StationService.java
+++ b/src/main/java/subway/station/application/StationService.java
@@ -1,15 +1,19 @@
-package subway;
+package subway.station.application;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import subway.station.dto.StationRequest;
+import subway.station.dto.StationResponse;
+import subway.station.domain.Station;
+import subway.station.domain.StationRepository;
 
 @Service
 @Transactional(readOnly = true)
 public class StationService {
-    private StationRepository stationRepository;
+    private final StationRepository stationRepository;
 
     public StationService(StationRepository stationRepository) {
         this.stationRepository = stationRepository;

--- a/src/main/java/subway/station/domain/Station.java
+++ b/src/main/java/subway/station/domain/Station.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station.domain;
 
 import javax.persistence.*;
 
@@ -7,6 +7,7 @@ public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     @Column(length = 20, nullable = false)
     private String name;
 

--- a/src/main/java/subway/station/domain/StationRepository.java
+++ b/src/main/java/subway/station/domain/StationRepository.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/subway/station/dto/StationRequest.java
+++ b/src/main/java/subway/station/dto/StationRequest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station.dto;
 
 public class StationRequest {
     private String name;

--- a/src/main/java/subway/station/dto/StationResponse.java
+++ b/src/main/java/subway/station/dto/StationResponse.java
@@ -1,8 +1,8 @@
-package subway;
+package subway.station.dto;
 
 public class StationResponse {
-    private Long id;
-    private String name;
+    private final Long id;
+    private final String name;
 
     public StationResponse(Long id, String name) {
         this.id = id;

--- a/src/main/java/subway/station/exception/StationNotFoundException.java
+++ b/src/main/java/subway/station/exception/StationNotFoundException.java
@@ -1,0 +1,10 @@
+package subway.station.exception;
+
+import subway.common.exception.BusinessException;
+import subway.common.exception.ErrorCode;
+
+public class StationNotFoundException extends BusinessException {
+    public StationNotFoundException() {
+        super(ErrorCode.STATION_NOT_FOUND_EXCEPTION);
+    }
+}

--- a/src/main/java/subway/station/presentation/StationController.java
+++ b/src/main/java/subway/station/presentation/StationController.java
@@ -1,14 +1,17 @@
-package subway;
+package subway.station.presentation;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 import java.util.List;
+import subway.station.dto.StationRequest;
+import subway.station.dto.StationResponse;
+import subway.station.application.StationService;
 
 @RestController
 public class StationController {
-    private StationService stationService;
+    private final StationService stationService;
 
     public StationController(StationService stationService) {
         this.stationService = stationService;

--- a/src/test/java/subway/AcceptanceTest.java
+++ b/src/test/java/subway/AcceptanceTest.java
@@ -1,0 +1,11 @@
+package subway;
+
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql(scripts = "/beforeclass.sql", executionPhase = AFTER_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public abstract class AcceptanceTest {
+}

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -1,0 +1,46 @@
+package subway;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class LineAcceptanceTest {
+    /**
+     * When: 지하철 노선을 생성하면
+     * Then: 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
+     */
+    @Test
+    void createLine() {
+
+    }
+
+    /**
+     * Given: 2개의 지하철 노선을 생성하고
+     * When: 지하철 노선 목록을 조회하면
+     * Then: 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다
+     */
+    @Test
+    void findAllLines() {
+
+    }
+
+    /**
+     * Given: 지하철 노선을 생성하고
+     * When: 생성한 지하철 노선을 조회하면
+     * Then: 생성한 지하철 노선의 정보를 응답받을 수 있다
+     */
+    @Test
+    void findLine() {
+
+    }
+
+    /**
+     * Given: 지하철 노선을 생성하고
+     * When: 생성한 지하철 노선을 삭제하면
+     * Then: 해당 지하철 노선 정보는 삭제된다
+     */
+    @Test
+    void deleteLine() {
+
+    }
+}

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -3,6 +3,14 @@ package subway;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+/**
+ * 프로그래밍 요구사항
+ * - 아래의 순서로 기능을 구현한다
+ *   1. 인수 조건을 검증하는 인수 테스트를 작성한다
+ *   2. 인수 테스트를 충족하는 기능을 구현한다
+ * - 인수 테스트의 결과가 서로 영향을 끼치지 않도록 인수테스트를 서로 격리시킨다
+ * - 인수 테스트의 재사용성과 가독성, 그리고 빠른 테스트 의도 파악을 위해 인수 테스트를 리팩터링한다
+ */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class LineAcceptanceTest {
     /**

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import subway.station.domain.Station;
 
 /**
  * 프로그래밍 요구사항

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -1,7 +1,16 @@
 package subway;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 /**
  * 프로그래밍 요구사항
@@ -41,7 +50,36 @@ public class LineAcceptanceTest {
          * - stations[] : 해당 노선에 속한 상행 지하철역과 하행 지하철역 리스트
          */
 
+        // when
+        Map<String, Object> params = Map.of(
+                "name", "신분당선",
+                "color", "bg-red-600",
+                "upstationId", 1L,
+                "downStationId", 2L,
+                "distance", 10
+        );
 
+        ExtractableResponse<Response> responseOfCreate = RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(responseOfCreate.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        ExtractableResponse<Response> responseOfRead = RestAssured.given().log().all()
+                .pathParam("id", 1L)  // lineId를 넣어야 한다
+                .when().get("/lines")
+                .then().log().all()
+                .extract();
+
+        long lineId = responseOfRead.jsonPath().getLong("id");
+        List<Station> stations = responseOfRead.jsonPath().getList("stations", Station.class);
+
+        assertThat(lineId).isEqualTo(1L);  // lineId를 넣어야 한다
+        assertThat(stations).hasSize(2);  // 상행과 하행 두개가 있으므로 size는 2여야 한다
     }
 
     /**

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -27,9 +27,9 @@ public class LineAcceptanceTest {
          * Body
          * - name : 지하철 노선 이름 (ex: "신분당선")
          * - color : 지하철 노선 색상 (ex: "bg-red-600")
-         * - upStationId : 상행 측면의 역 (ex: "상행 A - B - C 하행" 일 때 B의 upStation=A)
-         * - downStationId : 하행 측면의 역 (ex: "상행 A - B - C 하행" 일 때 B의 downStation=C)
-         * - distance: ???
+         * - upStationId : 상행 측면의 역 (ex: "상행 A - B 하행" 일 때 upStation=A)
+         * - downStationId : 하행 측면의 역 (ex: "상행 A - B 하행" 일 때 downStation=B)
+         * - distance: upStation과 downStation간의 거리
          *
          * ## Response
          * 201 Created
@@ -40,6 +40,7 @@ public class LineAcceptanceTest {
          * - color : 생성된 지하철 노선 색상 (요청 명세 참고)
          * - stations[] : 해당 노선에 속한 상행 지하철역과 하행 지하철역 리스트
          */
+
 
     }
 

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -19,6 +19,27 @@ public class LineAcceptanceTest {
      */
     @Test
     void createLine() {
+        /* # API 명세
+         *
+         * ## Request
+         * POST /lines
+         * Content-Type: application/json
+         * Body
+         * - name : 지하철 노선 이름 (ex: "신분당선")
+         * - color : 지하철 노선 색상 (ex: "bg-red-600")
+         * - upStationId : 상행 측면의 역 (ex: "상행 A - B - C 하행" 일 때 B의 upStation=A)
+         * - downStationId : 하행 측면의 역 (ex: "상행 A - B - C 하행" 일 때 B의 downStation=C)
+         * - distance: ???
+         *
+         * ## Response
+         * 201 Created
+         * Location: /lines/1
+         * Content-Type: application/json
+         * - id : 생성된 지하철 노선의 id값 (ex: 1)
+         * - name : 생성된 지하철 노선의 이름 (요청 명세 참고)
+         * - color : 생성된 지하철 노선 색상 (요청 명세 참고)
+         * - stations[] : 해당 노선에 속한 상행 지하철역과 하행 지하철역 리스트
+         */
 
     }
 

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -86,49 +86,12 @@ public class LineAcceptanceTest {
     }
 
     /**
-     * Given: 지하철 노선을 생성하고
-     * When: 생성한 지하철 노선을 조회하면
-     * Then: 생성한 지하철 노선의 정보를 응답받을 수 있다
-     */
-    @Test
-    void findLine() {
-        // given
-        지정된_이름의_지하철역을_생성한다("강남역");
-        지정된_이름의_지하철역을_생성한다("양재역");
-        지정된_이름의_지하철_노선을_생성한다("신분당선", 1L, 2L);
-
-        // when
-        ExtractableResponse<Response> result = 지하철_노선을_조회한다(1L);
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(result.jsonPath().getLong("id")).isEqualTo(1L);
-    }
-
-    /**
      * Given: 2개의 지하철 노선을 생성하고
      * When: 지하철 노선 목록을 조회하면
      * Then: 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다
      */
     @Test
     void findAllLines() {
-        /* # API 명세
-         *
-         * ## Request
-         * GET /lines
-         * Accept: application/json
-         *
-         * ## Response
-         * status: 200 OK
-         * Content-Type: application/json
-         * Body: 아래의 내용이 List 형태로 들어감
-         * - id : 생성된 지하철 노선의 id값 (ex: 1)
-         * - name : 생성된 지하철 노선의 이름 ("신분당선")
-         * - color : 생성된 지하철 노선 색상 ("bg-red-600")
-         * - stations[] : 해당 노선에 속한 상행 지하철역과 하행 지하철역 리스트
-         *   - id : 지하철역 id
-         *   - name : 지하철역 이름
-         */
         // given
         지정된_이름의_지하철역을_생성한다("강남역");
         지정된_이름의_지하철역을_생성한다("양재역");
@@ -151,6 +114,36 @@ public class LineAcceptanceTest {
 
     /**
      * Given: 지하철 노선을 생성하고
+     * When: 생성한 지하철 노선을 조회하면
+     * Then: 생성한 지하철 노선의 정보를 응답받을 수 있다
+     */
+    @Test
+    void findLine() {
+        // given
+        지정된_이름의_지하철역을_생성한다("강남역");
+        지정된_이름의_지하철역을_생성한다("양재역");
+        지정된_이름의_지하철_노선을_생성한다("신분당선", 1L, 2L);
+
+        // when
+        ExtractableResponse<Response> result = 지하철_노선을_조회한다(1L);
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(result.jsonPath().getLong("id")).isEqualTo(1L);
+    }
+
+    /**
+     * Given: 지하철 노선을 생성하고
+     * When: 생성한 지하철 노선을 수정하면
+     * Then: 해당 지하철 노선 정보는 수정된다
+     */
+    @Test
+    void updateLine() {
+
+    }
+
+    /**
+     * Given: 지하철 노선을 생성하고
      * When: 생성한 지하철 노선을 삭제하면
      * Then: 해당 지하철 노선 정보는 삭제된다
      */
@@ -159,6 +152,8 @@ public class LineAcceptanceTest {
         /* # API 명세
          *
          * ## Request
+         * GET /lines
+         * Accept: application/json
          *
          * ## Response
          */

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -143,7 +143,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         // then
         assertThat(responseOfDelete.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 
-        ExtractableResponse<Response> responseOfShowLine = LineRequest.지하철_노선을_조회한다(lineId);
-        assertThat(responseOfShowLine.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());  //TODO 없는 지하철 노선을 조회했으므로 예외가 발생할 것. 하지만 내가 ExceptionHandler를 따로 구현해주지 않았기 때문에 정해진 형식으로 내려오지 않는 문제가 있다. 어떻게 할지 고민 !
+        ExtractableResponse<Response> responseAfterDelete = LineRequest.지하철_노선을_조회한다(lineId);
+        assertThat(responseAfterDelete.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
 }

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.line;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -5,13 +5,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import subway.station.domain.Station;
 
 /**
  * 프로그래밍 요구사항
@@ -51,11 +49,14 @@ public class LineAcceptanceTest {
          * - stations[] : 해당 노선에 속한 상행 지하철역과 하행 지하철역 리스트
          */
 
+        지정된_이름의_지하철역을_생성한다("가양역");
+        지정된_이름의_지하철역을_생성한다("여의도역");
+
         // when
         Map<String, Object> params = Map.of(
                 "name", "신분당선",
                 "color", "bg-red-600",
-                "upstationId", 1L,
+                "upStationId", 1L,  //TODO 고정된 id값이 아닌, 저장된 역의 id값을 사용해야 함
                 "downStationId", 2L,
                 "distance", 10
         );
@@ -70,17 +71,29 @@ public class LineAcceptanceTest {
         // then
         assertThat(responseOfCreate.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
-        ExtractableResponse<Response> responseOfRead = RestAssured.given().log().all()
-                .pathParam("id", 1L)  // lineId를 넣어야 한다
-                .when().get("/lines")
-                .then().log().all()
-                .extract();
+        //TODO: 아래 인수 테스트는 조회 로직 구현 후에 다시해보기
+//        long id = responseOfCreate.jsonPath().getLong("id");
+//        ExtractableResponse<Response> responseOfRead = RestAssured.given().log().all()
+//                .pathParam("id", id)  // lineId를 넣어야 한다
+//                .when().get("/lines/{id}")
+//                .then().log().all()
+//                .extract();
+//
+//        long lineId = responseOfRead.jsonPath().getLong("id");
+//        List<Station> stations = responseOfRead.jsonPath().getList("stations", Station.class);
+//
+//        assertThat(lineId).isEqualTo(1L);  // lineId를 넣어야 한다
+//        assertThat(stations).hasSize(2);  // 상행과 하행 두개가 있으므로 size는 2여야 한다
+    }
 
-        long lineId = responseOfRead.jsonPath().getLong("id");
-        List<Station> stations = responseOfRead.jsonPath().getList("stations", Station.class);
+    private void 지정된_이름의_지하철역을_생성한다(String stationName) {
+        Map<String, String> params = Map.of("name", stationName);
 
-        assertThat(lineId).isEqualTo(1L);  // lineId를 넣어야 한다
-        assertThat(stations).hasSize(2);  // 상행과 하행 두개가 있으므로 size는 2여야 한다
+        RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all();
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -192,7 +192,7 @@ public class LineAcceptanceTest {
         /* # API 명세
          *
          * ## Request
-         * DELETE /lines
+         * DELETE /lines/{id}
          *
          * ## Response
          * status: 204 NoContent
@@ -213,6 +213,6 @@ public class LineAcceptanceTest {
         assertThat(responseOfDelete.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 
         ExtractableResponse<Response> responseOfShowLine = 지하철_노선을_조회한다(1L);
-        assertThat(responseOfShowLine.statusCode()).isEqualTo(HttpStatus.OK.value());  //TODO 없는 지하철 노선을 조회했으므로 예외가 발생할 것. 하지만 내가 ExceptionHandler를 따로 구현해주지 않았기 때문에 정해진 형식으로 내려오지 않는 문제가 있다. 어떻게 할지 고민 !
+        assertThat(responseOfShowLine.statusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());  //TODO 없는 지하철 노선을 조회했으므로 예외가 발생할 것. 하지만 내가 ExceptionHandler를 따로 구현해주지 않았기 때문에 정해진 형식으로 내려오지 않는 문제가 있다. 어떻게 할지 고민 !
     }
 }

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -29,10 +29,7 @@ public class LineAcceptanceTest extends AcceptanceTest {
         long createdLineId = 지하철_노선_Id를_추출한다(responseOfCreate);
         ExtractableResponse<Response> responseOfRead = LineRequest.지하철_노선을_조회한다(createdLineId);
 
-        long findLineId = 지하철_노선_Id를_추출한다(responseOfRead);
         String findLineName = 지하철_노선_이름을_추출한다(responseOfRead);
-
-        assertThat(findLineId).isEqualTo(createdLineId);
         assertThat(findLineName).isEqualTo(lineName);
     }
 

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -85,11 +85,12 @@ public class LineAcceptanceTest {
         ExtractableResponse<Response> responseOfCreateLine = LineRequest.지하철_노선을_생성한다("강남역", "양재역", "신분당선");
 
         // when
-        ExtractableResponse<Response> responseOfFindLine = LineRequest.지하철_노선을_조회한다(지하철_노선_Id를_추출한다(responseOfCreateLine));
+        long lineId = 지하철_노선_Id를_추출한다(responseOfCreateLine);
+        ExtractableResponse<Response> responseOfFindLine = LineRequest.지하철_노선을_조회한다(lineId);
 
         // then
         assertThat(responseOfFindLine.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(지하철_노선_Id를_추출한다(responseOfFindLine)).isEqualTo(1L);
+        assertThat(지하철_노선_Id를_추출한다(responseOfFindLine)).isEqualTo(lineId);
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -27,30 +27,8 @@ public class LineAcceptanceTest {
      */
     @Test
     void createLine() {
-        /* # API 명세
-         *
-         * ## Request
-         * POST /lines
-         * Content-Type: application/json
-         * Body
-         * - name : 지하철 노선 이름 (ex: "신분당선")
-         * - color : 지하철 노선 색상 (ex: "bg-red-600")
-         * - upStationId : 상행 측면의 역 (ex: "상행 A - B 하행" 일 때 upStation=A)
-         * - downStationId : 하행 측면의 역 (ex: "상행 A - B 하행" 일 때 downStation=B)
-         * - distance: upStation과 downStation간의 거리
-         *
-         * ## Response
-         * 201 Created
-         * Location: /lines/1
-         * Content-Type: application/json
-         * - id : 생성된 지하철 노선의 id값 (ex: 1)
-         * - name : 생성된 지하철 노선의 이름 (요청 명세 참고)
-         * - color : 생성된 지하철 노선 색상 (요청 명세 참고)
-         * - stations[] : 해당 노선에 속한 상행 지하철역과 하행 지하철역 리스트
-         */
-
-        지정된_이름의_지하철역을_생성한다("가양역");
-        지정된_이름의_지하철역을_생성한다("여의도역");
+        지정된_이름의_지하철역을_생성한다("강남역");
+        지정된_이름의_지하철역을_생성한다("양재역");
 
         // when
         Map<String, Object> params = Map.of(
@@ -86,6 +64,7 @@ public class LineAcceptanceTest {
 //        assertThat(stations).hasSize(2);  // 상행과 하행 두개가 있으므로 size는 2여야 한다
     }
 
+    //TODO: 해당 로직은 StationAcceptanceTest와 중복이 된다. 어떻게 해결할 지 고민
     private void 지정된_이름의_지하철역을_생성한다(String stationName) {
         Map<String, String> params = Map.of("name", stationName);
 
@@ -97,23 +76,44 @@ public class LineAcceptanceTest {
     }
 
     /**
-     * Given: 2개의 지하철 노선을 생성하고
-     * When: 지하철 노선 목록을 조회하면
-     * Then: 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다
-     */
-    @Test
-    void findAllLines() {
-
-    }
-
-    /**
      * Given: 지하철 노선을 생성하고
      * When: 생성한 지하철 노선을 조회하면
      * Then: 생성한 지하철 노선의 정보를 응답받을 수 있다
      */
     @Test
     void findLine() {
+        /* # API 명세
+         *
+         * ## Request
+         * GET /lines/{id}
+         * Accept: application/json
+         *
+         * ## Response
+         * status: 200 OK
+         * Content-Type: application/json
+         * Body
+         * - id : 생성된 지하철 노선의 id값 (ex: 1)
+         * - name : 생성된 지하철 노선의 이름 ("신분당선")
+         * - color : 생성된 지하철 노선 색상 ("bg-red-600")
+         * - stations[] : 해당 노선에 속한 상행 지하철역과 하행 지하철역 리스트
+         *   - id : 지하철역 id
+         *   - name : 지하철역 이름
+         */
+    }
 
+    /**
+     * Given: 2개의 지하철 노선을 생성하고
+     * When: 지하철 노선 목록을 조회하면
+     * Then: 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다
+     */
+    @Test
+    void findAllLines() {
+        /* # API 명세
+         *
+         * ## Request
+         *
+         * ## Response
+         */
     }
 
     /**
@@ -123,6 +123,11 @@ public class LineAcceptanceTest {
      */
     @Test
     void deleteLine() {
-
+        /* # API 명세
+         *
+         * ## Request
+         *
+         * ## Response
+         */
     }
 }

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -139,7 +139,42 @@ public class LineAcceptanceTest {
      */
     @Test
     void updateLine() {
+        /* # API 명세
+         *
+         * ## Request
+         * PUT /lines/{id}
+         * Content-Type: application/json
+         * Body
+         * - name : 수정하고자 하는 이름
+         * - color : 수정하고자 하는 색상
+         *
+         * ## Response
+         * status: 200 OK
+         */
+        // given
+        지정된_이름의_지하철역을_생성한다("강남역");
+        지정된_이름의_지하철역을_생성한다("양재역");
+        지정된_이름의_지하철_노선을_생성한다("신분당선", 1L, 2L);
 
+        // when
+        Map<String, String> params = Map.of(
+                "name", "구분당선",
+                "color", "bg-sky-500"
+        );
+
+        ExtractableResponse<Response> responseOfUpdate = RestAssured.given().log().all()
+                .body(params)
+                .pathParam("id", 1L)
+                .when().put("/lines/{id}")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(responseOfUpdate.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        ExtractableResponse<Response> responseOfShowLine = 지하철_노선을_조회한다(1L);
+        assertThat(responseOfShowLine.jsonPath().getString("name")).isEqualTo("구분당선");
+        assertThat(responseOfShowLine.jsonPath().getString("color")).isEqualTo("bg-sky-500");
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -10,14 +10,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import subway.AcceptanceTest;
 
-/**
- * 프로그래밍 요구사항
- * - 아래의 순서로 기능을 구현한다
- *   1. 인수 조건을 검증하는 인수 테스트를 작성한다
- *   2. 인수 테스트를 충족하는 기능을 구현한다
- * - 인수 테스트의 결과가 서로 영향을 끼치지 않도록 인수테스트를 서로 격리시킨다
- * - 인수 테스트의 재사용성과 가독성, 그리고 빠른 테스트 의도 파악을 위해 인수 테스트를 리팩터링한다
- */
 @DisplayName("지하철 노선 관련 기능")
 public class LineAcceptanceTest extends AcceptanceTest {
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -192,10 +192,27 @@ public class LineAcceptanceTest {
         /* # API 명세
          *
          * ## Request
-         * GET /lines
-         * Accept: application/json
+         * DELETE /lines
          *
          * ## Response
+         * status: 204 NoContent
          */
+        // given
+        지정된_이름의_지하철역을_생성한다("강남역");
+        지정된_이름의_지하철역을_생성한다("양재역");
+        지정된_이름의_지하철_노선을_생성한다("신분당선", 1L, 2L);
+
+        // when
+        ExtractableResponse<Response> responseOfDelete = RestAssured.given().log().all()
+                .pathParam("id", 1L)
+                .when().delete("/lines/{id}")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(responseOfDelete.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+
+        ExtractableResponse<Response> responseOfShowLine = 지하철_노선을_조회한다(1L);
+        assertThat(responseOfShowLine.statusCode()).isEqualTo(HttpStatus.OK.value());  //TODO 없는 지하철 노선을 조회했으므로 예외가 발생할 것. 하지만 내가 ExceptionHandler를 따로 구현해주지 않았기 때문에 정해진 형식으로 내려오지 않는 문제가 있다. 어떻게 할지 고민 !
     }
 }

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -139,18 +139,6 @@ public class LineAcceptanceTest {
      */
     @Test
     void updateLine() {
-        /* # API 명세
-         *
-         * ## Request
-         * PUT /lines/{id}
-         * Content-Type: application/json
-         * Body
-         * - name : 수정하고자 하는 이름
-         * - color : 수정하고자 하는 색상
-         *
-         * ## Response
-         * status: 200 OK
-         */
         // given
         지정된_이름의_지하철역을_생성한다("강남역");
         지정된_이름의_지하철역을_생성한다("양재역");
@@ -189,14 +177,6 @@ public class LineAcceptanceTest {
      */
     @Test
     void deleteLine() {
-        /* # API 명세
-         *
-         * ## Request
-         * DELETE /lines/{id}
-         *
-         * ## Response
-         * status: 204 NoContent
-         */
         // given
         지정된_이름의_지하철역을_생성한다("강남역");
         지정된_이름의_지하철역을_생성한다("양재역");

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -31,20 +31,7 @@ public class LineAcceptanceTest {
         지정된_이름의_지하철역을_생성한다("양재역");
 
         // when
-        Map<String, Object> params = Map.of(
-                "name", "신분당선",
-                "color", "bg-red-600",
-                "upStationId", 1L,  //TODO 고정된 id값이 아닌, 저장된 역의 id값을 사용해야 함
-                "downStationId", 2L,
-                "distance", 10
-        );
-
-        ExtractableResponse<Response> responseOfCreate = RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> responseOfCreate = 지하철_노선을_생성한다();
 
         // then
         assertThat(responseOfCreate.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -75,6 +62,23 @@ public class LineAcceptanceTest {
                 .then().log().all();
     }
 
+    private ExtractableResponse<Response> 지하철_노선을_생성한다() {
+        Map<String, Object> params = Map.of(
+                "name", "신분당선",
+                "color", "bg-red-600",
+                "upStationId", 1L,  //TODO 고정된 id값이 아닌, 저장된 역의 id값을 사용해야 함
+                "downStationId", 2L,
+                "distance", 10
+        );
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all()
+                .extract();
+    }
+
     /**
      * Given: 지하철 노선을 생성하고
      * When: 생성한 지하철 노선을 조회하면
@@ -100,7 +104,21 @@ public class LineAcceptanceTest {
          *   - name : 지하철역 이름
          */
 
+        // given
+        지정된_이름의_지하철역을_생성한다("강남역");
+        지정된_이름의_지하철역을_생성한다("양재역");
+        지하철_노선을_생성한다();
 
+        // when
+        ExtractableResponse<Response> result = RestAssured.given().log().all()
+                .pathParam("id", 1L)
+                .when().get("/lines/{id}")
+                .then().log().all()
+                .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value());
+        assertThat(result.jsonPath().getLong("id")).isEqualTo(1L);
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -30,10 +30,9 @@ public class LineAcceptanceTest {
      */
     @Test
     void createLine() {
+        // when
         지정된_이름의_지하철역을_생성한다("강남역");
         지정된_이름의_지하철역을_생성한다("양재역");
-
-        // when
         ExtractableResponse<Response> responseOfCreate = 지정된_이름의_지하철_노선을_생성한다("신분당선", 1L, 2L);
 
         // then
@@ -60,6 +59,7 @@ public class LineAcceptanceTest {
                 .when().post("/stations")
                 .then().log().all();
     }
+
     private ExtractableResponse<Response> 지정된_이름의_지하철_노선을_생성한다(String lineName, Long upStationId, Long downStationId) {
         Map<String, Object> params = Map.of(
                 "name", lineName,

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -99,6 +99,8 @@ public class LineAcceptanceTest {
          *   - id : 지하철역 id
          *   - name : 지하철역 이름
          */
+
+
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import subway.line.dto.LineResponse;
 import subway.line.dto.StationOnLineResponse;
 
 /**
@@ -145,7 +146,7 @@ public class LineAcceptanceTest {
 
         // then
         assertThat(result.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(result.jsonPath().getList("", StationOnLineResponse.class)).hasSize(2);
+        assertThat(result.jsonPath().getList("", LineResponse.class)).hasSize(2);
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -4,11 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import subway.line.dto.LineResponse;
 
 /**
  * 프로그래밍 요구사항
@@ -70,7 +70,11 @@ public class LineAcceptanceTest {
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-        assertThat(response.jsonPath().getList("", LineResponse.class)).hasSize(2);
+        assertThat(지하철_노선_목록_이름을_추출한다(response)).hasSize(2);
+    }
+
+    private List<String> 지하철_노선_목록_이름을_추출한다(ExtractableResponse<Response> response) {
+        return response.jsonPath().getList("name", String.class);
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -157,17 +157,7 @@ public class LineAcceptanceTest {
         지정된_이름의_지하철_노선을_생성한다("신분당선", 1L, 2L);
 
         // when
-        Map<String, String> params = Map.of(
-                "name", "구분당선",
-                "color", "bg-sky-500"
-        );
-
-        ExtractableResponse<Response> responseOfUpdate = RestAssured.given().log().all()
-                .body(params)
-                .pathParam("id", 1L)
-                .when().put("/lines/{id}")
-                .then().log().all()
-                .extract();
+        ExtractableResponse<Response> responseOfUpdate = 지하철_노선을_수정한다();
 
         // then
         assertThat(responseOfUpdate.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -175,6 +165,21 @@ public class LineAcceptanceTest {
         ExtractableResponse<Response> responseOfShowLine = 지하철_노선을_조회한다(1L);
         assertThat(responseOfShowLine.jsonPath().getString("name")).isEqualTo("구분당선");
         assertThat(responseOfShowLine.jsonPath().getString("color")).isEqualTo("bg-sky-500");
+    }
+
+    private ExtractableResponse<Response> 지하철_노선을_수정한다() {
+        Map<String, String> params = Map.of(
+                "name", "구분당선",
+                "color", "bg-sky-500"
+        );
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .pathParam("id", 1L)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put("/lines/{id}")
+                .then().log().all()
+                .extract();
     }
 
     /**

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -7,8 +7,8 @@ import io.restassured.response.Response;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import subway.AcceptanceTest;
 
 /**
  * 프로그래밍 요구사항
@@ -19,8 +19,7 @@ import org.springframework.http.HttpStatus;
  * - 인수 테스트의 재사용성과 가독성, 그리고 빠른 테스트 의도 파악을 위해 인수 테스트를 리팩터링한다
  */
 @DisplayName("지하철 노선 관련 기능")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class LineAcceptanceTest {
+public class LineAcceptanceTest extends AcceptanceTest {
     /**
      * When: 지하철 노선을 생성하면
      * Then: 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다

--- a/src/test/java/subway/line/LineAcceptanceTest.java
+++ b/src/test/java/subway/line/LineAcceptanceTest.java
@@ -18,6 +18,7 @@ import subway.line.dto.LineResponse;
  * - 인수 테스트의 결과가 서로 영향을 끼치지 않도록 인수테스트를 서로 격리시킨다
  * - 인수 테스트의 재사용성과 가독성, 그리고 빠른 테스트 의도 파악을 위해 인수 테스트를 리팩터링한다
  */
+@DisplayName("지하철 노선 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class LineAcceptanceTest {
     /**

--- a/src/test/java/subway/line/LineRequest.java
+++ b/src/test/java/subway/line/LineRequest.java
@@ -1,0 +1,75 @@
+package subway.line;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.springframework.http.MediaType;
+import subway.station.StationRequest;
+
+public class LineRequest {
+    private LineRequest() {
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선을_생성한다(String upStationName, String downStationName, String lineName) {
+        ExtractableResponse<Response> responseOfUpStation = StationRequest.지하철역을_생성한다(upStationName);
+        ExtractableResponse<Response> responseOfDownStation = StationRequest.지하철역을_생성한다(downStationName);
+
+        Map<String, Object> params = Map.of(
+                "name", lineName,
+                "color", "bg-red-600",
+                "upStationId", extractId(responseOfUpStation),
+                "downStationId", extractId(responseOfDownStation),
+                "distance", 10
+        );
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+    private static long extractId(ExtractableResponse<Response> responseOfCreateStation) {
+        return responseOfCreateStation.jsonPath().getLong("id");
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선을_조회한다(long lineId) {
+        return RestAssured.given().log().all()
+                .pathParam("id", lineId)
+                .when().get("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_목록을_조회한다() {
+        return RestAssured.given().log().all()
+                .when().get("/lines")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선을_수정한다(long lineId, String lineName, String color) {
+        Map<String, String> params = Map.of(
+                "name", lineName,
+                "color", color
+        );
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .pathParam("id", lineId)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선을_삭제한다(long lineId) {
+        return RestAssured.given().log().all()
+                .pathParam("id", lineId)
+                .when().delete("/lines/{id}")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -74,11 +74,8 @@ public class StationAcceptanceTest {
     void deleteStationById() {
         //given
         String 가양역 = "가양역";
-        StationRequest.지하철역을_생성한다(가양역);
-
-        ExtractableResponse<Response> responseOfShowStations = StationRequest.지하철역_목록을_조회한다();
-        List<Long> stationIds = 지하철역_목록_Id를_추출한다(responseOfShowStations);
-        Long stationId = stationIds.get(0);
+        ExtractableResponse<Response> responseOfCreateStation = StationRequest.지하철역을_생성한다(가양역);
+        long stationId = responseOfCreateStation.jsonPath().getLong("id");
 
         //when
         ExtractableResponse<Response> responseOfDeleteStation = StationRequest.지하철역을_삭제한다(stationId);
@@ -89,7 +86,7 @@ public class StationAcceptanceTest {
         ExtractableResponse<Response> responseOfShowStationsAfterDelete = StationRequest.지하철역_목록을_조회한다();
         List<Long> stationIdsAfterDelete = 지하철역_목록_Id를_추출한다(responseOfShowStationsAfterDelete);
 
-        assertThat(stationIdsAfterDelete).hasSize(0);
+        assertThat(stationIdsAfterDelete).doesNotContain(stationId);
     }
 
     private List<Long> 지하철역_목록_Id를_추출한다(ExtractableResponse<Response> responseOfShowStations) {

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -2,16 +2,13 @@ package subway.station;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -25,28 +22,17 @@ public class StationAcceptanceTest {
     @Test
     void createStation() {
         // when
-        String 강남역 = "강남역";
-        ExtractableResponse<Response> response = 지정된_이름의_지하철역을_생성하고_응답결과를_받아온다(강남역);
+        String stationName = "강남역";
+        ExtractableResponse<Response> responseOfCreateStation = StationRequest.지하철역을_생성한다(stationName);
 
         // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+        assertThat(responseOfCreateStation.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        ExtractableResponse<Response> responseOfShowStations = 지하철역_목록을_조회한다();
+        ExtractableResponse<Response> responseOfShowStations = StationRequest.지하철역_목록을_조회한다();
         List<String> stationNames = 지하철역_목록_이름을_추출한다(responseOfShowStations);
 
-        assertThat(stationNames).containsAnyOf(강남역);
-    }
-
-    private ExtractableResponse<Response> 지정된_이름의_지하철역을_생성하고_응답결과를_받아온다(String stationName) {
-        Map<String, String> params = Map.of("name", stationName);
-
-        return RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations")
-                .then().log().all()
-                .extract();
+        assertThat(stationNames).containsAnyOf(stationName);
     }
 
     /**
@@ -59,13 +45,13 @@ public class StationAcceptanceTest {
     void findAllStations() {
         //given
         String 가양역 = "가양역";
-        지정된_이름의_지하철역을_생성한다(가양역);
+        StationRequest.지하철역을_생성한다(가양역);
 
         String 여의도역 = "여의도역";
-        지정된_이름의_지하철역을_생성한다(여의도역);
+        StationRequest.지하철역을_생성한다(여의도역);
 
         //when
-        ExtractableResponse<Response> response = 지하철역_목록을_조회한다();
+        ExtractableResponse<Response> response = StationRequest.지하철역_목록을_조회한다();
 
         //then
         List<String> stationNames = 지하철역_목록_이름을_추출한다(response);
@@ -74,25 +60,8 @@ public class StationAcceptanceTest {
         assertThat(stationNames).contains(가양역, 여의도역);
     }
 
-    private ExtractableResponse<Response> 지하철역_목록을_조회한다() {
-        return RestAssured.given().log().all()
-                .when().get("/stations")  //TODO /stations 가 다른 path로 변경된다면?
-                .then().log().all()
-                .extract();
-    }
-
     private List<String> 지하철역_목록_이름을_추출한다(ExtractableResponse<Response> responseOfShowStations) {
         return responseOfShowStations.jsonPath().getList("name", String.class);
-    }
-
-    private void 지정된_이름의_지하철역을_생성한다(String stationName) {
-        Map<String, String> params = Map.of("name", stationName);
-
-        RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations")
-                .then().log().all();
     }
 
     /**
@@ -105,19 +74,19 @@ public class StationAcceptanceTest {
     void deleteStationById() {
         //given
         String 가양역 = "가양역";
-        지정된_이름의_지하철역을_생성한다(가양역);
+        StationRequest.지하철역을_생성한다(가양역);
 
-        ExtractableResponse<Response> responseOfShowStations = 지하철역_목록을_조회한다();
+        ExtractableResponse<Response> responseOfShowStations = StationRequest.지하철역_목록을_조회한다();
         List<Long> stationIds = 지하철역_목록_Id를_추출한다(responseOfShowStations);
         Long stationId = stationIds.get(0);
 
         //when
-        ExtractableResponse<Response> responseOfDeleteStation = 지하철역을_삭제한다(stationId);
+        ExtractableResponse<Response> responseOfDeleteStation = StationRequest.지하철역을_삭제한다(stationId);
 
         //then
         assertThat(responseOfDeleteStation.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 
-        ExtractableResponse<Response> responseOfShowStationsAfterDelete = 지하철역_목록을_조회한다();
+        ExtractableResponse<Response> responseOfShowStationsAfterDelete = StationRequest.지하철역_목록을_조회한다();
         List<Long> stationIdsAfterDelete = 지하철역_목록_Id를_추출한다(responseOfShowStationsAfterDelete);
 
         assertThat(stationIdsAfterDelete).hasSize(0);
@@ -125,13 +94,5 @@ public class StationAcceptanceTest {
 
     private List<Long> 지하철역_목록_Id를_추출한다(ExtractableResponse<Response> responseOfShowStations) {
         return responseOfShowStations.jsonPath().getList("id", Long.class);
-    }
-
-    private ExtractableResponse<Response> 지하철역을_삭제한다(Long stationId) {
-        return RestAssured.given().log().all()
-                .pathParam("id", stationId)
-                .when().delete("/stations/{id}")
-                .then().log().all()
-                .extract();
     }
 }

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -74,7 +74,7 @@ public class StationAcceptanceTest extends AcceptanceTest {
         //given
         String 가양역 = "가양역";
         ExtractableResponse<Response> responseOfCreateStation = StationRequest.지하철역을_생성한다(가양역);
-        long stationId = responseOfCreateStation.jsonPath().getLong("id");
+        long stationId = 지하철역_Id를_추출한다(responseOfCreateStation);
 
         //when
         ExtractableResponse<Response> responseOfDeleteStation = StationRequest.지하철역을_삭제한다(stationId);
@@ -86,6 +86,10 @@ public class StationAcceptanceTest extends AcceptanceTest {
         List<Long> stationIdsAfterDelete = 지하철역_목록_Id를_추출한다(responseOfShowStationsAfterDelete);
 
         assertThat(stationIdsAfterDelete).doesNotContain(stationId);
+    }
+
+    private long 지하철역_Id를_추출한다(ExtractableResponse<Response> responseOfCreateStation) {
+        return responseOfCreateStation.jsonPath().getLong("id");
     }
 
     private List<Long> 지하철역_목록_Id를_추출한다(ExtractableResponse<Response> responseOfShowStations) {

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -7,12 +7,11 @@ import io.restassured.response.Response;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import subway.AcceptanceTest;
 
 @DisplayName("지하철역 관련 기능")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class StationAcceptanceTest {
+public class StationAcceptanceTest extends AcceptanceTest {
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -1,18 +1,17 @@
-package subway;
+package subway.station;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-
-import java.util.List;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -32,7 +32,8 @@ public class StationAcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        List<String> stationNames = 지하철역_목록_이름을_조회한다();
+        ExtractableResponse<Response> responseOfShowStations = 지하철역_목록을_조회한다();
+        List<String> stationNames = responseOfShowStations.jsonPath().getList("name", String.class);
 
         assertThat(stationNames).containsAnyOf(강남역);
     }
@@ -64,23 +65,20 @@ public class StationAcceptanceTest {
         지정된_이름의_지하철역을_생성한다(여의도역);
 
         //when
-        List<String> stationNames = 지하철역_목록_이름을_조회한다();  //TODO 지하철역 이름은 2개의 지하철역을 응답받는다에 대한 수단이므로, Then절에서 이루어지는 게 좋아보임
+        ExtractableResponse<Response> response = 지하철역_목록을_조회한다();
 
         //then
+        List<String> stationNames = response.jsonPath().getList("name", String.class);
+
         assertThat(stationNames).hasSize(2);
         assertThat(stationNames).contains(가양역, 여의도역);
     }
 
-    /**
-     * TODO 아래 두 가지 역할을 수행하는 메서드를 추출 해보는 것은 어떨까?
-     *  1. GET /stations
-     *  2. 응답으로 부터 name 추출
-     */
-    private List<String> 지하철역_목록_이름을_조회한다() {
+    private ExtractableResponse<Response> 지하철역_목록을_조회한다() {
         return RestAssured.given().log().all()
                 .when().get("/stations")  //TODO /stations 가 다른 path로 변경된다면?
                 .then().log().all()
-                .extract().jsonPath().getList("name", String.class);  //TODO 이름 뿐만 아니라, 다른 내용들도 조회하고 싶다면?
+                .extract();
     }
 
     private void 지정된_이름의_지하철역을_생성한다(String stationName) {
@@ -105,25 +103,20 @@ public class StationAcceptanceTest {
         String 가양역 = "가양역";
         지정된_이름의_지하철역을_생성한다(가양역);
 
-        List<Long> stationIds = 지하철역_목록_Id를_조회한다();
+        ExtractableResponse<Response> responseOfShowStations = 지하철역_목록을_조회한다();
+        List<Long> stationIds = responseOfShowStations.jsonPath().getList("id", Long.class);
         Long stationId = stationIds.get(0);
 
         //when
-        ExtractableResponse<Response> response = 지하철역을_삭제한다(stationId);
+        ExtractableResponse<Response> responseOfDeleteStation = 지하철역을_삭제한다(stationId);
 
         //then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(responseOfDeleteStation.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 
-        List<Long> stationIdsAfterDelete = 지하철역_목록_Id를_조회한다();
+        ExtractableResponse<Response> responseOfShowStationsAfterDelete = 지하철역_목록을_조회한다();
+        List<Long> stationIdsAfterDelete = responseOfShowStationsAfterDelete.jsonPath().getList("id", Long.class);
 
         assertThat(stationIdsAfterDelete).hasSize(0);
-    }
-
-    private List<Long> 지하철역_목록_Id를_조회한다() {
-        return RestAssured.given().log().all()
-                .when().get("/stations")
-                .then().log().all()
-                .extract().jsonPath().getList("id", Long.class);
     }
 
     private ExtractableResponse<Response> 지하철역을_삭제한다(Long stationId) {

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -64,18 +64,23 @@ public class StationAcceptanceTest {
         지정된_이름의_지하철역을_생성한다(여의도역);
 
         //when
-        List<String> stationNames = 지하철역_목록_이름을_조회한다();
+        List<String> stationNames = 지하철역_목록_이름을_조회한다();  //TODO 지하철역 이름은 2개의 지하철역을 응답받는다에 대한 수단이므로, Then절에서 이루어지는 게 좋아보임
 
         //then
         assertThat(stationNames).hasSize(2);
         assertThat(stationNames).contains(가양역, 여의도역);
     }
 
+    /**
+     * TODO 아래 두 가지 역할을 수행하는 메서드를 추출 해보는 것은 어떨까?
+     *  1. GET /stations
+     *  2. 응답으로 부터 name 추출
+     */
     private List<String> 지하철역_목록_이름을_조회한다() {
         return RestAssured.given().log().all()
-                .when().get("/stations")
+                .when().get("/stations")  //TODO /stations 가 다른 path로 변경된다면?
                 .then().log().all()
-                .extract().jsonPath().getList("name", String.class);
+                .extract().jsonPath().getList("name", String.class);  //TODO 이름 뿐만 아니라, 다른 내용들도 조회하고 싶다면?
     }
 
     private void 지정된_이름의_지하철역을_생성한다(String stationName) {

--- a/src/test/java/subway/station/StationAcceptanceTest.java
+++ b/src/test/java/subway/station/StationAcceptanceTest.java
@@ -33,7 +33,7 @@ public class StationAcceptanceTest {
 
         // then
         ExtractableResponse<Response> responseOfShowStations = 지하철역_목록을_조회한다();
-        List<String> stationNames = responseOfShowStations.jsonPath().getList("name", String.class);
+        List<String> stationNames = 지하철역_목록_이름을_추출한다(responseOfShowStations);
 
         assertThat(stationNames).containsAnyOf(강남역);
     }
@@ -68,7 +68,7 @@ public class StationAcceptanceTest {
         ExtractableResponse<Response> response = 지하철역_목록을_조회한다();
 
         //then
-        List<String> stationNames = response.jsonPath().getList("name", String.class);
+        List<String> stationNames = 지하철역_목록_이름을_추출한다(response);
 
         assertThat(stationNames).hasSize(2);
         assertThat(stationNames).contains(가양역, 여의도역);
@@ -79,6 +79,10 @@ public class StationAcceptanceTest {
                 .when().get("/stations")  //TODO /stations 가 다른 path로 변경된다면?
                 .then().log().all()
                 .extract();
+    }
+
+    private List<String> 지하철역_목록_이름을_추출한다(ExtractableResponse<Response> responseOfShowStations) {
+        return responseOfShowStations.jsonPath().getList("name", String.class);
     }
 
     private void 지정된_이름의_지하철역을_생성한다(String stationName) {
@@ -104,7 +108,7 @@ public class StationAcceptanceTest {
         지정된_이름의_지하철역을_생성한다(가양역);
 
         ExtractableResponse<Response> responseOfShowStations = 지하철역_목록을_조회한다();
-        List<Long> stationIds = responseOfShowStations.jsonPath().getList("id", Long.class);
+        List<Long> stationIds = 지하철역_목록_Id를_추출한다(responseOfShowStations);
         Long stationId = stationIds.get(0);
 
         //when
@@ -114,9 +118,13 @@ public class StationAcceptanceTest {
         assertThat(responseOfDeleteStation.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
 
         ExtractableResponse<Response> responseOfShowStationsAfterDelete = 지하철역_목록을_조회한다();
-        List<Long> stationIdsAfterDelete = responseOfShowStationsAfterDelete.jsonPath().getList("id", Long.class);
+        List<Long> stationIdsAfterDelete = 지하철역_목록_Id를_추출한다(responseOfShowStationsAfterDelete);
 
         assertThat(stationIdsAfterDelete).hasSize(0);
+    }
+
+    private List<Long> 지하철역_목록_Id를_추출한다(ExtractableResponse<Response> responseOfShowStations) {
+        return responseOfShowStations.jsonPath().getList("id", Long.class);
     }
 
     private ExtractableResponse<Response> 지하철역을_삭제한다(Long stationId) {

--- a/src/test/java/subway/station/StationRequest.java
+++ b/src/test/java/subway/station/StationRequest.java
@@ -1,0 +1,38 @@
+package subway.station;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.springframework.http.MediaType;
+
+public class StationRequest {
+    private StationRequest() {
+    }
+
+    public static ExtractableResponse<Response> 지하철역을_생성한다(String stationName) {
+        Map<String, String> params = Map.of("name", stationName);
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철역_목록을_조회한다() {
+        return RestAssured.given().log().all()
+                .when().get("/stations")  //TODO /stations 가 다른 path로 변경된다면?
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철역을_삭제한다(Long stationId) {
+        return RestAssured.given().log().all()
+                .pathParam("id", stationId)
+                .when().delete("/stations/{id}")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/subway/station/StationRequest.java
+++ b/src/test/java/subway/station/StationRequest.java
@@ -28,7 +28,7 @@ public class StationRequest {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 지하철역을_삭제한다(Long stationId) {
+    public static ExtractableResponse<Response> 지하철역을_삭제한다(long stationId) {
         return RestAssured.given().log().all()
                 .pathParam("id", stationId)
                 .when().delete("/stations/{id}")

--- a/src/test/resources/beforeclass.sql
+++ b/src/test/resources/beforeclass.sql
@@ -1,0 +1,2 @@
+delete from line;
+delete from station;


### PR DESCRIPTION
# 인수테스트 관련 
## 선택한 인수 테스트 격리 방법과 선택 이유 
- `@Sql` 애너테이션과 `test/resource/beforeclass.sql` 내부에 `delete from {table이름}` 쿼리를 이용하여 격리하였습니다.
- `@DirtiesContext`를 이용하면 편리하긴 했겠지만, 매번 컨텍스트를 재로딩한다는 것이 큰 비용이 될 수도 있겠다고 생각했습니다.


---

# 비즈니스로직 관련 
## 패키지 구조 
- layered architecture를 참고하여 구성 해보았습니다. 
- 계층은 크게 `application`, `domain`, `presentation`으로 나누었고, 부가적으로 `exception`과 `dto`패키지를 구성했습니다. 



### `dto`패키지를 따로 둔 이유
처음에는 `XxxRequest`는 `presentation`에, `XxxResponse`는 `application`에 위치시켰으나, 이럴 경우 `presentation`과 `application` 패키지 간 의존성이 생기더라구요..😅  

`presentation`은 `application`에 의존해도, `application`은 `presentation`계층에 의존하지 않도록, 나름 의존관계의 방향성을 고려 해보고 싶었습니다.

- 첫 번째 시도 방안: 모든 DTO를 `application` 패키지에 위치 
  - `XxxRequest`는 어찌보면 `presentation` 레이어에서 만들어지는 DTO인데(정확히는 HttpMessageConverter), `application`패키지에 위치하는게 뭔가 어색하다고 생각했습니다. 그래서 시도만 하고 바로 철회했습니다. 😅


- 두 번째 시도 방안: `dto`패키지를 생성 후 공용 패키지처럼(?) 사용 
  - [인프런 김영한선생님 답변 글](https://www.inflearn.com/questions/24222/dto-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EC%9C%84%EC%B9%98-%EA%B4%80%EB%A0%A8)을 참고해서 `XxxRequest`와 `XxxResponse`는 `application`과 `presentation`이 공용으로 사용한다고 판단하고 `dto`패키지를 따로 만들어 해당 패키지에 위치시켰습니다.


결론적으로 두 번째 방안을 선택했는데, 어떤 더 좋은 방안이 있는지는 생각하지 못했네요. 🥲

혹시 리뷰어님께서는 DTO를 어떤 방식으로, 혹은 어떤 기준으로 관리하고 계신가요? 
