### PR TITLE
E2e step2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ dependencies {
     // log
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
+    // guava
+    implementation 'com.google.guava:guava:32.1.1-jre'
+
+    // lombok
     compileOnly 'org.projectlombok:lombok:1.18.28'
     annotationProcessor 'org.projectlombok:lombok:1.18.28'
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,9 @@ dependencies {
     // log
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
 
+    compileOnly 'org.projectlombok:lombok:1.18.28'
+    annotationProcessor 'org.projectlombok:lombok:1.18.28'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:4.5.1'
 

--- a/src/main/java/subway/line/Line.java
+++ b/src/main/java/subway/line/Line.java
@@ -9,7 +9,6 @@ import javax.persistence.*;
 public class Line {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "line_id")
     private Long id;
 
     private String name;

--- a/src/main/java/subway/line/Line.java
+++ b/src/main/java/subway/line/Line.java
@@ -1,0 +1,29 @@
+package subway.line;
+
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+public class Line {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "line_id")
+    private Long id;
+
+    private String name;
+    private String color;
+
+    public Line() {}
+
+    public Line(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+
+    public void update(String name, String color) {
+        this.name = name;
+        this.color = color;
+    }
+}

--- a/src/main/java/subway/line/LineController.java
+++ b/src/main/java/subway/line/LineController.java
@@ -1,0 +1,44 @@
+package subway.line;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.List;
+
+@RestController
+public class LineController {
+    private final LineService lineService;
+
+    public LineController(LineService lineService) {
+        this.lineService = lineService;
+    }
+
+    @GetMapping("/lines")
+    public ResponseEntity<List<LineResponse>> showLines() {
+        return ResponseEntity.ok().body(lineService.findAllLines());
+    }
+
+    @PostMapping("/lines")
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
+        LineResponse line = lineService.saveLine(lineRequest);
+        return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
+    }
+
+    @GetMapping("/lines/{id}")
+    public ResponseEntity<LineResponse> showLine(@PathVariable Long id) {
+        return ResponseEntity.ok().body(lineService.findLineById(id));
+    }
+
+    @PutMapping("/lines/{id}")
+    public ResponseEntity<Void> updateLine(@PathVariable Long id, @RequestBody LineRequest lineRequest) {
+        lineService.updateLine(id, lineRequest);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/lines/{id}")
+    public ResponseEntity<Void> deleteLine(@PathVariable Long id) {
+        lineService.deleteLineById(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/subway/line/LineRepository.java
+++ b/src/main/java/subway/line/LineRepository.java
@@ -1,0 +1,6 @@
+package subway.line;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LineRepository extends JpaRepository<Line, Long>  {
+}

--- a/src/main/java/subway/line/LineRequest.java
+++ b/src/main/java/subway/line/LineRequest.java
@@ -1,0 +1,9 @@
+package subway.line;
+
+import lombok.Getter;
+
+@Getter
+public class LineRequest {
+    private String name;
+    private String color;
+}

--- a/src/main/java/subway/line/LineResponse.java
+++ b/src/main/java/subway/line/LineResponse.java
@@ -1,0 +1,19 @@
+package subway.line;
+
+import lombok.Getter;
+import subway.station.Station;
+
+import java.util.List;
+
+@Getter
+public class LineResponse {
+    private Long id;
+    private String name;
+    private String color;
+
+    public LineResponse(Long id, String name, String color) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+    }
+}

--- a/src/main/java/subway/line/LineService.java
+++ b/src/main/java/subway/line/LineService.java
@@ -1,0 +1,52 @@
+package subway.line;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional(readOnly = true)
+public class LineService {
+    private LineRepository lineRepository;
+
+    public LineService(LineRepository lineRepository) {
+        this.lineRepository = lineRepository;
+    }
+
+    @Transactional
+    public LineResponse saveLine(LineRequest lineRequest) {
+        Line line = lineRepository.save(new Line(lineRequest.getName(), lineRequest.getColor()));
+        return createLineResponse(line);
+    }
+
+    public List<LineResponse> findAllLines() {
+        return lineRepository.findAll().stream()
+                .map(this::createLineResponse)
+                .collect(Collectors.toList());
+    }
+
+    public LineResponse findLineById(Long id) {
+        return createLineResponse(lineRepository.findById(id).orElseThrow(IllegalArgumentException::new));
+    }
+
+    @Transactional
+    public void updateLine(Long id, LineRequest lineRequest) {
+        Line line = lineRepository.findById(id).orElseThrow(IllegalArgumentException::new);
+        line.update(lineRequest.getName(), lineRequest.getColor());
+    }
+
+    @Transactional
+    public void deleteLineById(Long id) {
+        lineRepository.deleteById(id);
+    }
+
+    private LineResponse createLineResponse(Line line) {
+        return new LineResponse(
+                line.getId(),
+                line.getName(),
+                line.getColor()
+        );
+    }
+}

--- a/src/main/java/subway/station/Station.java
+++ b/src/main/java/subway/station/Station.java
@@ -8,7 +8,6 @@ import javax.persistence.*;
 public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "station_id")
     private Long id;
     @Column(length = 20, nullable = false)
     private String name;

--- a/src/main/java/subway/station/Station.java
+++ b/src/main/java/subway/station/Station.java
@@ -1,4 +1,6 @@
-package subway;
+package subway.station;
+
+import subway.line.Line;
 
 import javax.persistence.*;
 
@@ -6,6 +8,7 @@ import javax.persistence.*;
 public class Station {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "station_id")
     private Long id;
     @Column(length = 20, nullable = false)
     private String name;

--- a/src/main/java/subway/station/StationController.java
+++ b/src/main/java/subway/station/StationController.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/subway/station/StationRepository.java
+++ b/src/main/java/subway/station/StationRepository.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/subway/station/StationRequest.java
+++ b/src/main/java/subway/station/StationRequest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station;
 
 public class StationRequest {
     private String name;

--- a/src/main/java/subway/station/StationResponse.java
+++ b/src/main/java/subway/station/StationResponse.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station;
 
 public class StationResponse {
     private Long id;

--- a/src/main/java/subway/station/StationService.java
+++ b/src/main/java/subway/station/StationService.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.station;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/src/test/java/subway/AcceptanceTest.java
+++ b/src/test/java/subway/AcceptanceTest.java
@@ -1,0 +1,31 @@
+package subway;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+
+import static io.restassured.RestAssured.UNDEFINED_PORT;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@SpringBootTest(webEnvironment = RANDOM_PORT)
+@ActiveProfiles("acceptance")
+public abstract class AcceptanceTest {
+
+    @LocalServerPort
+    protected int port;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+
+    @BeforeEach
+    void setUp() {
+        if (RestAssured.port == UNDEFINED_PORT) {
+            RestAssured.port = port;
+            databaseCleanup.afterPropertiesSet();
+        }
+        databaseCleanup.execute();
+    }
+}

--- a/src/test/java/subway/DatabaseCleanup.java
+++ b/src/test/java/subway/DatabaseCleanup.java
@@ -1,0 +1,45 @@
+package subway;
+
+import com.google.common.base.CaseFormat;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Profile("acceptance")
+public class DatabaseCleanup implements InitializingBean{
+    @PersistenceContext
+    private EntityManager entityManager;
+    private List<String> tableNames;
+    @Override
+    public void afterPropertiesSet() {
+        tableNames = entityManager.getMetamodel().getEntities().stream()
+                .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+                .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        // 쓰기 지연 저장소에 남은 SQL을 마저 수행
+        entityManager.flush();
+        // 연관 관계 맵핑된 테이블이 있는 경우 참조 무결성을 해제해줘야 Trancate 가능
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            // 테이블 이름 순회하며 Trancate SQL 수행
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+            // 테이블의 내부가 지워지면 그 다음부터는 ID값을 다시 1부터 시작할 수 있도록 기본 값 초기화
+            entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN "
+                    + "ID RESTART WITH 1").executeUpdate();
+        }
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/src/test/java/subway/HttpRequest.java
+++ b/src/test/java/subway/HttpRequest.java
@@ -17,6 +17,15 @@ public class HttpRequest {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> sendPutRequest(String path, Map<String, String> params) {
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().put(path)
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> sendDeleteRequest(String path) {
         return RestAssured.given().log().all()
                 .when().delete(path)

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -12,74 +12,16 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@DisplayName("지하철역 관련 기능")
-public class StationAcceptanceTest  extends AcceptanceTest {
-    private final String STATION_API_PATH = "/stations";
+@DisplayName("지하철 노선 관련 기능")
+public class LineAcceptanceTest extends AcceptanceTest {
     private final String LINE_API_PATH = "/lines";
-    private final String STATION_GANGNAM = "강남역";
-    private final String STATION_SAMSUNG = "삼성역";
     private final String LINE_SHINBUNDANG = "신분당선";
     private final String LINE_1 = "1호선";
     private final String COLOR_CODE_RED = "bg-red-600";
     private final String COLOR_CODE_BLUE = "bg-blue-600";
     private final String PARAM_NAME = "name";
-    private final String PARAM_STATION_ID = "id";
     private final String PARAM_LINE_ID = "id";
     private final String PARAM_COLOR = "color";
-
-    /**
-     * When 지하철역을 생성하면
-     * Then 지하철역이 생성된다
-     * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
-     */
-    @DisplayName("지하철역을 생성한다.")
-    @Test
-    void 지하철_역_생성_테스트() {
-        // when & then
-        지하철_역_생성(STATION_GANGNAM);
-
-        // then
-        List<String> stationNames = getJsonPathList(지하철_역_목록_조회(), PARAM_NAME);
-        assertThat(stationNames).containsAnyOf(STATION_GANGNAM);
-    }
-
-    /**
-     * Given 2개의 지하철역을 생성하고
-     * When 지하철역 목록을 조회하면
-     * Then 2개의 지하철역을 응답 받는다
-     */
-    @DisplayName("지하철역 목록을 조회한다.")
-    @Test
-    void 지하철_역_목록_조회_테스트() {
-        // given
-        지하철_역_생성(STATION_GANGNAM);
-        지하철_역_생성(STATION_SAMSUNG);
-
-        // when
-        List<String> stationNames = getJsonPathList(지하철_역_목록_조회(), PARAM_NAME);
-
-        // then
-        assertThat(stationNames).containsOnly(STATION_GANGNAM, STATION_SAMSUNG);
-    }
-
-    /**
-     * Given 지하철역을 생성하고
-     * When 그 지하철역을 삭제하면
-     * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
-     */
-    @DisplayName("지하철역을 삭제한다.")
-    @Test
-    void 지하철_역_삭제_테스트() {
-        // given
-        long stationId = 지하철_역_생성(STATION_GANGNAM).jsonPath().getLong(PARAM_STATION_ID);
-
-        // when
-        지하철_역_삭제(stationId);
-
-        // then
-        List<String> stationNames = getJsonPathList(지하철_역_목록_조회(), PARAM_NAME);
-        assertThat(stationNames).doesNotContainAnyElementsOf(List.of(STATION_GANGNAM));
-    }
 
     /**
      * 지하철 노선 생성
@@ -176,32 +118,6 @@ public class StationAcceptanceTest  extends AcceptanceTest {
         // then
         List<String> lineNames = getJsonPathList(지하철_노선_목록_조회(), PARAM_NAME);
         assertThat(lineNames).doesNotContainAnyElementsOf(List.of(LINE_SHINBUNDANG));
-    }
-
-    private ExtractableResponse<Response> 지하철_역_생성(String name) {
-        Map<String, String> params = generateStationParams(name);
-        ExtractableResponse<Response> response = HttpRequest.sendPostRequest(STATION_API_PATH, params);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-
-        return response;
-    }
-
-    private ExtractableResponse<Response> 지하철_역_목록_조회() {
-        ExtractableResponse<Response> response = HttpRequest.sendGetRequest(STATION_API_PATH);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-
-        return response;
-    }
-
-    private void 지하철_역_삭제(long stationId) {
-        ExtractableResponse<Response> response = HttpRequest.sendDeleteRequest(STATION_API_PATH + "/" + stationId);
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-    }
-
-    private Map<String, String> generateStationParams(String name) {
-        Map<String, String> params = new HashMap<>();
-        params.put(PARAM_NAME, name);
-        return params;
     }
 
     private List<String> getJsonPathList(ExtractableResponse<Response> response, String path) {

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -17,10 +17,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class StationAcceptanceTest {
     private final String STATION_API_PATH = "/stations";
+    private final String LINE_API_PATH = "/lines";
     private final String STATION_GANGNAM = "강남역";
     private final String STATION_SAMSUNG = "삼성역";
+    private final String LINE_SHINBUNDANG = "신분당선";
+    private final String LINE_1 = "1호선";
+    private final String COLOR_CODE_RED = "bg-red-600";
+    private final String COLOR_CODE_BLUE = "bg-blue-600";
     private final String PARAM_NAME = "name";
     private final String PARAM_STATION_ID = "id";
+    private final String PARAM_LINE_ID = "id";
 
     /**
      * When 지하철역을 생성하면
@@ -29,12 +35,12 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 생성한다.")
     @Test
-    void 지하철역_생성_테스트() {
+    void 지하철_역_생성_테스트() {
         // when & then
-        지하철역_생성(STATION_GANGNAM);
+        지하철_역_생성(STATION_GANGNAM);
 
         // then
-        List<String> stationNames = getJsonPathList(지하철역_목록_조회(), PARAM_NAME);
+        List<String> stationNames = getJsonPathList(지하철_역_목록_조회(), PARAM_NAME);
         assertThat(stationNames).containsAnyOf(STATION_GANGNAM);
     }
 
@@ -45,13 +51,13 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역 목록을 조회한다.")
     @Test
-    void 지하철역_목록_조회_테스트() {
+    void 지하철_역_목록_조회_테스트() {
         // given
-        지하철역_생성(STATION_GANGNAM);
-        지하철역_생성(STATION_SAMSUNG);
+        지하철_역_생성(STATION_GANGNAM);
+        지하철_역_생성(STATION_SAMSUNG);
 
         // when
-        List<String> stationNames = getJsonPathList(지하철역_목록_조회(), PARAM_NAME);
+        List<String> stationNames = getJsonPathList(지하철_역_목록_조회(), PARAM_NAME);
 
         // then
         assertThat(stationNames).containsOnly(STATION_GANGNAM, STATION_SAMSUNG);
@@ -64,19 +70,116 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 삭제한다.")
     @Test
-    void 지하철역_삭제_테스트() {
+    void 지하철_역_삭제_테스트() {
         // given
-        long stationId = 지하철역_생성(STATION_GANGNAM).jsonPath().getLong(PARAM_STATION_ID);
+        long stationId = 지하철_역_생성(STATION_GANGNAM).jsonPath().getLong(PARAM_STATION_ID);
 
         // when
-        지하철역_삭제(stationId);
+        지하철_역_삭제(stationId);
 
         // then
-        List<String> stationNames = getJsonPathList(지하철역_목록_조회(), PARAM_NAME);
+        List<String> stationNames = getJsonPathList(지하철_역_목록_조회(), PARAM_NAME);
         assertThat(stationNames).doesNotContainAnyElementsOf(List.of(STATION_GANGNAM));
     }
 
-    private ExtractableResponse<Response> 지하철역_생성(String name) {
+    /**
+     * 지하철 노선 생성
+     * 노선 생성 시 상행종점역과 하행종점역을 등록
+     * When 지하철 노선을 생성하면
+     * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
+     */
+    @DisplayName("지하철 노선을 생성한다.")
+    @Test
+    void 지하철_노선_생성_테스트() {
+        // when & then
+        지하철_노선_생성(LINE_SHINBUNDANG, COLOR_CODE_RED,1, 2);
+
+        // then
+        List<String> lineNames = getJsonPathList(지하철_노선_목록_조회(), PARAM_NAME);
+        assertThat(lineNames).containsAnyOf(LINE_SHINBUNDANG);
+    }
+
+    /**
+     * 지하철 노선 목록 조회
+     * Given 2개의 지하철 노선을 생성하고
+     * When 지하철 노선 목록을 조회하면
+     * Then 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다
+     */
+    @DisplayName("지하철 노선 목록을 조회한다.")
+    @Test
+    void 지하철_노선_목록_조회_테스트() {
+        // given
+        지하철_노선_생성(LINE_SHINBUNDANG, COLOR_CODE_RED,1, 2);
+        지하철_노선_생성(LINE_1, COLOR_CODE_RED,1, 2);
+
+        // when
+        List<String> lineNames = getJsonPathList(지하철_노선_목록_조회(), PARAM_NAME);
+
+        // then
+        assertThat(lineNames).containsOnly(LINE_SHINBUNDANG, LINE_1);
+    }
+
+    /**
+     * 지하철 노선 조회
+     * 노선 조회시 포함된 역 목록이 함께 응답
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 조회하면
+     * Then 생성한 지하철 노선의 정보를 응답받을 수 있다
+     */
+    @DisplayName("지하철 노선을 조회한다.")
+    @Test
+    void 지하철_노선_조회_테스트() {
+        // given
+        지하철_노선_생성(LINE_SHINBUNDANG, COLOR_CODE_RED,1, 2, 10);
+
+        // when
+        List<String> lineNames = getJsonPathList(지하철_노선_조회(1), PARAM_NAME);
+
+        // then
+        assertThat(lineNames).containsOnly(LINE_SHINBUNDANG);
+    }
+
+    /**
+     * 지하철 노선 수정
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 수정하면
+     * Then 해당 지하철 노선 정보는 수정된다
+     */
+    @DisplayName("지하철 노선을 수정한다.")
+    @Test
+    void 지하철_노선_수정_테스트() {
+        // given
+        지하철_노선_생성(LINE_SHINBUNDANG, COLOR_CODE_RED,1, 2, 10);
+
+        // when
+        지하철_노선_수정(1, LINE_1, COLOR_CODE_BLUE);
+
+        // then
+        List<String> lineNames = getJsonPathList(지하철_노선_조회(1), PARAM_NAME);
+        assertThat(lineNames).containsOnly(LINE_1);
+    }
+
+    /**
+     * 지하철 노선 삭제
+     * Given 지하철 노선을 생성하고
+     * When 생성한 지하철 노선을 삭제하면
+     * Then 해당 지하철 노선 정보는 삭제된다
+     */
+    @DisplayName("지하철 노선을 삭제한다.")
+    @Test
+    void 지하철_노선_삭제_테스트() {
+        // given
+        long lineId = 지하철_노선_생성(LINE_SHINBUNDANG, COLOR_CODE_RED,1, 2, 10).jsonPath().getLong(PARAM_LINE_ID);
+
+        // when
+        지하철_노선_삭제(lineId);
+
+        // then
+        List<String> lineNames = getJsonPathList(지하철_노선_목록_조회(), PARAM_NAME);
+        assertThat(lineNames).doesNotContainAnyElementsOf(List.of(LINE_SHINBUNDANG));
+    }
+
+    private ExtractableResponse<Response> 지하철_역_생성(String name) {
         Map<String, String> params = generateStationParams(name);
         ExtractableResponse<Response> response = HttpRequest.sendPostRequest(STATION_API_PATH, params);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -84,14 +187,14 @@ public class StationAcceptanceTest {
         return response;
     }
 
-    private ExtractableResponse<Response> 지하철역_목록_조회() {
+    private ExtractableResponse<Response> 지하철_역_목록_조회() {
         ExtractableResponse<Response> response = HttpRequest.sendGetRequest(STATION_API_PATH);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
 
         return response;
     }
 
-    private void 지하철역_삭제(long stationId) {
+    private void 지하철_역_삭제(long stationId) {
         ExtractableResponse<Response> response = HttpRequest.sendDeleteRequest(STATION_API_PATH + "/" + stationId);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
@@ -104,5 +207,46 @@ public class StationAcceptanceTest {
 
     private List<String> getJsonPathList(ExtractableResponse<Response> response, String path) {
         return response.jsonPath().getList(path, String.class);
+    }
+
+    private Map<String, String> generateLineParams(String name) {
+        Map<String, String> params = new HashMap<>();
+        params.put(PARAM_NAME, name);
+        return params;
+    }
+
+    private ExtractableResponse<Response> 지하철_노선_생성(String name, String color, long upStationId, long downStationId, int distance) {
+        Map<String, String> params = generateLineParams(name);
+        ExtractableResponse<Response> response = HttpRequest.sendPostRequest(LINE_API_PATH, params);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        return response;
+    }
+
+    private ExtractableResponse<Response> 지하철_노선_목록_조회() {
+        ExtractableResponse<Response> response = HttpRequest.sendGetRequest(STATION_API_PATH);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        return response;
+    }
+
+    private ExtractableResponse<Response> 지하철_노선_조회(long lineId) {
+        ExtractableResponse<Response> response = HttpRequest.sendGetRequest(STATION_API_PATH);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        return response;
+    }
+
+    private ExtractableResponse<Response> 지하철_노선_수정(long lineId, String name, String color) {
+        Map<String, String> params = generateLineParams(name);
+        ExtractableResponse<Response> response = HttpRequest.sendPostRequest(LINE_API_PATH, params);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        return response;
+    }
+
+    private void 지하철_노선_삭제(long stationId) {
+        ExtractableResponse<Response> response = HttpRequest.sendDeleteRequest(STATION_API_PATH + "/" + stationId);
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 }


### PR DESCRIPTION
1. 지하철 노선 인수 테스트 작성
2. 지하철 노선 기능 구현
3. 인수테스트 격리를 위해 EntityManager를 활용한 Truncate 기능 구현(AcceptanceTest.class)

인수 테스트 격리 방안 별 장단점
1. @Transactional
- 트랜잭션 상태를 현재 스레드에 바인딩하게 되는데(ThreadLocal), 이 경우 해당 테스트 메서드의 모든 작업은 트랜잭션 내에서 호출되지 않고, 롤백도 되지않는다
- 결국 실제 DB에 커밋되게된다
- 공식 문서에서는 Timeout이 대표적인 새 스레드를 띄워 진행하는 작업이라 소개하고 있다
- 인수테스트 또한 @SpringBootTest 어노테이션에 port를 지정하여 서버를 띄우게 되는 데 이때, HTTP 클라이언트와 서버는 각각 다른 스레드에서 실행된다
- 따라서 아무리 테스트 코드에 @Transactional 어노테이션이 있다고 하더라도 호출되는 쪽은 다른 스레드에서 새로운 트랜잭션으로 커밋하기 때문에 롤백이 정상적으로 되지 않는다
2. DirtiesConext
- 매 테스트마다 ApplicationContext를 초기화해 테스트 격리가 가능하다
- 하지만, Spring boot의 기본 전략은 ApplicationContext를 캐싱해 재활용하는 것, 무거운 ApplicationContext를 초기화 후 재시작하는 것은 방지하고자 한다(너무 느리기 때문에)
- 너무 느려서 테스트가 많아지면 사용하기 어렵다
3. @Sql
- trancate를 사용해 직접 테이블 별 sql문을 작성해 DB 초기화
- DDL이라 delete보다 빠르다
- 테이블이 추가될 때 마다 일일이 sql문을 고쳐줘야한다
- sql문에 의존하게 되고, 관리 포인트가 많아서 조금 아쉽다
4. EntityManager
- 테이블 명을 불러와서 @Sql의 테이블 관리 단점을 상쇄
- 추상화해 모든 인수 테스트에 공통 적용 가능해 편리하고, 유지보수가 쉽고, 빠르다