### PR TITLE
🚀 1단계 - 지하철 구간 추가 기능 개선

### DIFF
--- a/src/main/java/subway/common/DatabaseCleaner.java
+++ b/src/main/java/subway/common/DatabaseCleaner.java
@@ -1,0 +1,36 @@
+package subway.common;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.EntityType;
+import javax.transaction.Transactional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner {
+    private final EntityManager entityManager;
+    private final List<String> tableNames;
+
+    public DatabaseCleaner(final EntityManager entityManager) {
+        this.entityManager = entityManager;
+        this.tableNames = entityManager.getMetamodel()
+            .getEntities()
+            .stream()
+            .map(EntityType::getName)
+            .map(String::toLowerCase)
+            .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+        for (String tableName : tableNames) {
+            entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+        }
+
+        entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+    }
+}

--- a/src/main/java/subway/controller/LineController.java
+++ b/src/main/java/subway/controller/LineController.java
@@ -3,9 +3,9 @@ package subway.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import subway.request.LineModifyRequest;
-import subway.request.LineRequest;
-import subway.response.LineResponse;
+import subway.dto.request.LineModifyRequest;
+import subway.dto.request.LineRequest;
+import subway.dto.response.LineResponse;
 import subway.service.LineService;
 
 import java.net.URI;
@@ -17,7 +17,7 @@ public class LineController {
     private final LineService lineService;
 
     @PostMapping("/lines")
-    public ResponseEntity<LineResponse> createStation(@RequestBody LineRequest request) {
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest request) {
         LineResponse line = lineService.saveLine(request);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
     }
@@ -29,7 +29,7 @@ public class LineController {
 
     @GetMapping("/lines/{id}")
     public ResponseEntity<LineResponse> findLine(@PathVariable Long id) {
-        LineResponse line = lineService.findLine(id);
+        LineResponse line = lineService.findLineResponse(id);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
     }
 

--- a/src/main/java/subway/controller/SectionController.java
+++ b/src/main/java/subway/controller/SectionController.java
@@ -1,0 +1,34 @@
+package subway.controller;
+
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import subway.dto.request.SectionRequest;
+import subway.service.SectionService;
+
+@RequestMapping("/lines/{id}/sections")
+@RestController
+@RequiredArgsConstructor
+public class SectionController {
+
+    private final SectionService sectionService;
+
+    @PostMapping
+    public ResponseEntity<Void> addSection(@PathVariable Long id, @RequestBody SectionRequest request) {
+        var section = sectionService.addSection(id, request);
+        return ResponseEntity.created(URI.create(String.format("/lines/%d/sections/%d", id, section.getId()))).build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteSection(@PathVariable Long id, Long stationId) {
+        sectionService.deleteSection(id, stationId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/subway/controller/SectionController.java
+++ b/src/main/java/subway/controller/SectionController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import subway.dto.request.SectionRequest;
+import subway.dto.response.LineResponse;
 import subway.service.SectionService;
 
 @RequestMapping("/lines/{id}/sections")
@@ -20,9 +21,9 @@ public class SectionController {
     private final SectionService sectionService;
 
     @PostMapping
-    public ResponseEntity<Void> addSection(@PathVariable Long id, @RequestBody SectionRequest request) {
-        var section = sectionService.addSection(id, request);
-        return ResponseEntity.created(URI.create(String.format("/lines/%d/sections/%d", id, section.getId()))).build();
+    public ResponseEntity<LineResponse> addSection(@PathVariable Long id, @RequestBody SectionRequest request) {
+        LineResponse line = sectionService.addSection(id, request);
+        return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
     }
 
     @DeleteMapping

--- a/src/main/java/subway/controller/StationController.java
+++ b/src/main/java/subway/controller/StationController.java
@@ -2,8 +2,8 @@ package subway.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import subway.request.StationRequest;
-import subway.response.StationResponse;
+import subway.dto.request.StationRequest;
+import subway.dto.response.StationResponse;
 import subway.service.StationService;
 
 import java.net.URI;

--- a/src/main/java/subway/dto/request/LineModifyRequest.java
+++ b/src/main/java/subway/dto/request/LineModifyRequest.java
@@ -1,4 +1,4 @@
-package subway.request;
+package subway.dto.request;
 
 
 import lombok.Builder;

--- a/src/main/java/subway/dto/request/LineRequest.java
+++ b/src/main/java/subway/dto/request/LineRequest.java
@@ -1,11 +1,11 @@
-package subway.dto;
+package subway.dto.request;
 
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class LineDto {
+public class LineRequest {
     private String name;
     private String color;
     private Long upStationId;
@@ -13,7 +13,7 @@ public class LineDto {
     private Long distance;
 
     @Builder
-    public LineDto(String name, String color, Long upStationId, Long downStationId, Long distance) {
+    public LineRequest(String name, String color, Long upStationId, Long downStationId, Long distance) {
         this.name = name;
         this.color = color;
         this.upStationId = upStationId;

--- a/src/main/java/subway/dto/request/SectionRequest.java
+++ b/src/main/java/subway/dto/request/SectionRequest.java
@@ -1,21 +1,16 @@
-package subway.request;
-
+package subway.dto.request;
 
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class LineRequest {
-    private String name;
-    private String color;
+public class SectionRequest {
     private Long upStationId;
     private Long downStationId;
     private Long distance;
 
     @Builder
-    public LineRequest(String name, String color, Long upStationId, Long downStationId, Long distance) {
-        this.name = name;
-        this.color = color;
+    public SectionRequest(Long upStationId, Long downStationId, Long distance) {
         this.upStationId = upStationId;
         this.downStationId = downStationId;
         this.distance = distance;

--- a/src/main/java/subway/dto/request/StationRequest.java
+++ b/src/main/java/subway/dto/request/StationRequest.java
@@ -1,4 +1,4 @@
-package subway.request;
+package subway.dto.request;
 
 public class StationRequest {
     private String name;

--- a/src/main/java/subway/dto/response/LineResponse.java
+++ b/src/main/java/subway/dto/response/LineResponse.java
@@ -1,4 +1,4 @@
-package subway.response;
+package subway.dto.response;
 
 
 import lombok.Builder;
@@ -12,10 +12,10 @@ public class LineResponse {
     private Long id;
     private String name;
     private String color;
-    private List<Station> stations;
+    private List<StationResponse> stations;
 
     @Builder
-    public LineResponse(Long id, String name, String color, List<Station> stations) {
+    public LineResponse(Long id, String name, String color, List<StationResponse> stations) {
         this.id = id;
         this.name = name;
         this.color = color;

--- a/src/main/java/subway/dto/response/LineResponse.java
+++ b/src/main/java/subway/dto/response/LineResponse.java
@@ -1,8 +1,10 @@
 package subway.dto.response;
 
 
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
+import subway.entity.Line;
 import subway.entity.Station;
 
 import java.util.List;
@@ -20,5 +22,16 @@ public class LineResponse {
         this.name = name;
         this.color = color;
         this.stations = stations;
+    }
+
+    public static LineResponse from(Line line) {
+        return LineResponse.builder()
+            .id(line.getId())
+            .name(line.getName())
+            .color(line.getColor())
+            .stations(line.getStations().stream()
+                .map(StationResponse::from)
+                .collect(Collectors.toList()))
+            .build();
     }
 }

--- a/src/main/java/subway/dto/response/LineResponse.java
+++ b/src/main/java/subway/dto/response/LineResponse.java
@@ -16,12 +16,15 @@ public class LineResponse {
     private String color;
     private List<StationResponse> stations;
 
+    private Long totalDistance;
+
     @Builder
-    public LineResponse(Long id, String name, String color, List<StationResponse> stations) {
+    public LineResponse(Long id, String name, String color, List<StationResponse> stations, Long totalDistance) {
         this.id = id;
         this.name = name;
         this.color = color;
         this.stations = stations;
+        this.totalDistance = totalDistance;
     }
 
     public static LineResponse from(Line line) {
@@ -32,6 +35,7 @@ public class LineResponse {
             .stations(line.getStations().stream()
                 .map(StationResponse::from)
                 .collect(Collectors.toList()))
+            .totalDistance(line.getSections().totalDistance())
             .build();
     }
 }

--- a/src/main/java/subway/dto/response/StationResponse.java
+++ b/src/main/java/subway/dto/response/StationResponse.java
@@ -1,9 +1,12 @@
-package subway.response;
+package subway.dto.response;
+
+import lombok.Builder;
 
 public class StationResponse {
     private Long id;
     private String name;
 
+    @Builder
     public StationResponse(Long id, String name) {
         this.id = id;
         this.name = name;

--- a/src/main/java/subway/dto/response/StationResponse.java
+++ b/src/main/java/subway/dto/response/StationResponse.java
@@ -1,6 +1,7 @@
 package subway.dto.response;
 
 import lombok.Builder;
+import subway.entity.Station;
 
 public class StationResponse {
     private Long id;
@@ -18,5 +19,13 @@ public class StationResponse {
 
     public String getName() {
         return name;
+    }
+
+
+    public static StationResponse from(Station station) {
+        return StationResponse.builder()
+            .id(station.getId())
+            .name(station.getName())
+            .build();
     }
 }

--- a/src/main/java/subway/entity/Line.java
+++ b/src/main/java/subway/entity/Line.java
@@ -1,13 +1,16 @@
 package subway.entity;
 
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import subway.request.LineModifyRequest;
-
-import javax.persistence.*;
-import java.util.Arrays;
-import java.util.List;
+import subway.dto.request.LineModifyRequest;
 
 @Getter
 @Entity
@@ -16,27 +19,25 @@ public class Line {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
     private String name;
+
     private String color;
-    @ManyToOne
-    @JoinColumn(name="up_station_id", nullable = false)
-    private Station upStation;
-    @ManyToOne
-    @JoinColumn(name="down_station_id", nullable = false)
-    private Station downStation;
-    private Long distance;
+
+    @Embedded
+    private Sections sections;
 
     @Builder
-    public Line(String name, String color, Station upStation, Station downStation, Long distance) {
+    public Line(String name, String color, Section section) {
         this.name = name;
         this.color = color;
-        this.upStation = upStation;
-        this.downStation = downStation;
-        this.distance = distance;
+        this.sections = Sections.builder()
+            .sections(Arrays.asList(section))
+            .build();
     }
 
     public List<Station> getStations() {
-        return Arrays.asList(this.upStation, this.downStation);
+        return this.sections.stations();
     }
 
     public void modify(LineModifyRequest request) {

--- a/src/main/java/subway/entity/Section.java
+++ b/src/main/java/subway/entity/Section.java
@@ -1,0 +1,41 @@
+package subway.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class Section {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name="up_station_id", nullable = false)
+    private Station upStation;
+
+    @ManyToOne
+    @JoinColumn(name="down_station_id", nullable = false)
+    private Station downStation;
+
+    private Long distance;
+
+    protected Section() {
+    }
+
+    @Builder
+    public Section(Station upStation, Station downStation, Long distance) {
+        this.upStation = upStation;
+        this.downStation = downStation;
+        this.distance = distance;
+    }
+}
+
+

--- a/src/main/java/subway/entity/Sections.java
+++ b/src/main/java/subway/entity/Sections.java
@@ -52,7 +52,7 @@ public class Sections {
         }
 
         // 마지막 구간의 하행역 아이디와 일치하는지 확인
-        var lastSection = sections.get(size - 1);
+        var lastSection = this.lastSection();
         if(!lastSection.getDownStation().getId().equals(stationId)) {
             throw new ApiException(ErrorCode.DELETE_BY_TERMINATE_STATION);
         }
@@ -69,5 +69,9 @@ public class Sections {
             .flatMap(o -> o.stream())
             .distinct()
             .collect(Collectors.toList());
+    }
+
+    public Long totalDistance() {
+        return this.sections.stream().mapToLong(o -> o.getDistance()).sum();
     }
 }

--- a/src/main/java/subway/entity/Sections.java
+++ b/src/main/java/subway/entity/Sections.java
@@ -36,7 +36,7 @@ public class Sections {
         }
 
         // 마지막 구간의 하행역과 추가하려는 구간의 상행역과 일치하는지 확인
-        var lastSection = sections.get(sections.size() - 1);
+        var lastSection = this.lastSection();
         if(!lastSection.getDownStation().equals(section.getUpStation())) {
             throw new ApiException(ErrorCode.INVALID_SECTION_REGISTRATION);
         }

--- a/src/main/java/subway/entity/Sections.java
+++ b/src/main/java/subway/entity/Sections.java
@@ -1,0 +1,73 @@
+package subway.entity;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.CascadeType;
+import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import subway.exception.ErrorCode;
+import subway.exception.ApiException;
+
+@Getter
+@Setter
+@Embeddable
+public class Sections {
+
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Section> sections = new ArrayList<>();
+
+    @Builder
+    public Sections(List<Section> sections) {
+        this.sections = sections;
+    }
+
+    protected Sections() {
+    }
+
+    public void addSection(Section section) {
+        // 이미 등록된 구간인 경우
+        if(stations().stream().anyMatch(o -> o.equals(section.getDownStation()))) {
+            throw new ApiException(ErrorCode.ALREADY_REGISTERED_STATION);
+        }
+
+        // 마지막 구간의 하행역과 추가하려는 구간의 상행역과 일치하는지 확인
+        var lastSection = sections.get(sections.size() - 1);
+        if(!lastSection.getDownStation().equals(section.getUpStation())) {
+            throw new ApiException(ErrorCode.INVALID_SECTION_REGISTRATION);
+        }
+
+        sections.add(section);
+    }
+
+    public void deleteSection(Long stationId) {
+        // 구간 개수 확인
+        var size = sections.size();
+        if(size == 1) {
+            throw new ApiException(ErrorCode.DELETE_OF_ONLY_ONE_SECTION);
+        }
+
+        // 마지막 구간의 하행역 아이디와 일치하는지 확인
+        var lastSection = sections.get(size - 1);
+        if(!lastSection.getDownStation().getId().equals(stationId)) {
+            throw new ApiException(ErrorCode.DELETE_BY_TERMINATE_STATION);
+        }
+
+        sections.remove(size - 1);
+    }
+
+    public Section lastSection() {
+        return sections.get(sections.size() - 1);
+    }
+
+    public List<Station> stations() {
+        return this.sections.stream().map(o -> Arrays.asList(o.getUpStation(), o.getDownStation()))
+            .flatMap(o -> o.stream())
+            .distinct()
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/subway/exception/ApiException.java
+++ b/src/main/java/subway/exception/ApiException.java
@@ -1,0 +1,20 @@
+package subway.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ApiException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public ApiException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public HttpStatus getStatus() {
+        return errorCode.getStatus();
+    }
+
+    public String getCode() {
+        return errorCode.getCode();
+    }
+}

--- a/src/main/java/subway/exception/ApiExceptionHandler.java
+++ b/src/main/java/subway/exception/ApiExceptionHandler.java
@@ -1,0 +1,18 @@
+package subway.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@ControllerAdvice
+public class ApiExceptionHandler {
+
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ErrorResponse> handleSubwayException(ApiException apiException) {
+        return new ResponseEntity<>(ErrorResponse.builder()
+            .httpStatus(apiException.getStatus())
+            .message(apiException.getMessage())
+            .errorCode(apiException.getCode())
+            .build(), apiException.getStatus());
+    }
+}

--- a/src/main/java/subway/exception/ErrorCode.java
+++ b/src/main/java/subway/exception/ErrorCode.java
@@ -1,0 +1,31 @@
+package subway.exception;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    INVALID_SECTION_REGISTRATION(BAD_REQUEST, "새로운 구간의 상행역은 노선에 등록된 마지막 구간의 하행역과 같아야 합니다."),
+    ALREADY_REGISTERED_STATION(BAD_REQUEST, "새로운 구간의 하행역은 노선에 등록되어 있는 구간들의 역과 중복될 수 없습니다."),
+    DELETE_BY_TERMINATE_STATION(BAD_REQUEST, "구간 삭제 시 하행 종점역을 입력해야 합니다."),
+    DELETE_OF_ONLY_ONE_SECTION(BAD_REQUEST, "하나의 구간만 있을 경우 삭제할 수 없습니다."),
+
+    STATION_NOT_FOUND(NOT_FOUND, "지하철역을 찾을 수 없습니다."),
+    LINE_NOT_FOUND(NOT_FOUND, "지하철 노선을 찾을 수 없습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return name();
+    }
+}

--- a/src/main/java/subway/exception/ErrorCode.java
+++ b/src/main/java/subway/exception/ErrorCode.java
@@ -9,10 +9,11 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
     INVALID_SECTION_REGISTRATION(BAD_REQUEST, "새로운 구간의 상행역은 노선에 등록된 마지막 구간의 하행역과 같아야 합니다."),
-    ALREADY_REGISTERED_STATION(BAD_REQUEST, "새로운 구간의 하행역은 노선에 등록되어 있는 구간들의 역과 중복될 수 없습니다."),
+    ALREADY_REGISTERED_SECTION(BAD_REQUEST, "이미 등록되어 있는 구간 입니다"),
+    NOT_CHAINING_SECTION(BAD_REQUEST, "상행역과 하행역 둘 중 하나도 포함되어있지 않아 연결될 수 없는 구간 입니다."),
+    INVALID_SECTION_DISTANCE(BAD_REQUEST, "잘못된 구간 길이 설정 입니다."),
     DELETE_BY_TERMINATE_STATION(BAD_REQUEST, "구간 삭제 시 하행 종점역을 입력해야 합니다."),
     DELETE_OF_ONLY_ONE_SECTION(BAD_REQUEST, "하나의 구간만 있을 경우 삭제할 수 없습니다."),
-
     STATION_NOT_FOUND(NOT_FOUND, "지하철역을 찾을 수 없습니다."),
     LINE_NOT_FOUND(NOT_FOUND, "지하철 노선을 찾을 수 없습니다."),
     ;

--- a/src/main/java/subway/exception/ErrorResponse.java
+++ b/src/main/java/subway/exception/ErrorResponse.java
@@ -1,0 +1,26 @@
+package subway.exception;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ErrorResponse {
+    private String errorCode;
+
+    private String status;
+
+    private String message;
+
+    @JsonIgnore
+    private HttpStatus httpStatus;
+
+    @Builder
+    public ErrorResponse(String errorCode, String status, String message, HttpStatus httpStatus) {
+        this.errorCode = errorCode;
+        this.status = status;
+        this.message = message;
+        this.httpStatus = httpStatus;
+    }
+}

--- a/src/main/java/subway/service/LineService.java
+++ b/src/main/java/subway/service/LineService.java
@@ -1,14 +1,17 @@
 package subway.service;
 
+import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import subway.dto.response.StationResponse;
 import subway.entity.Line;
+import subway.entity.Section;
 import subway.entity.Station;
 import subway.repository.LineRepository;
 import subway.repository.StationRepository;
-import subway.request.LineModifyRequest;
-import subway.request.LineRequest;
-import subway.response.LineResponse;
+import subway.dto.request.LineModifyRequest;
+import subway.dto.request.LineRequest;
+import subway.dto.response.LineResponse;
 
 import javax.transaction.Transactional;
 import java.util.List;
@@ -20,42 +23,55 @@ public class LineService {
     private final LineRepository lineRepository;
     private final StationRepository stationRepository;
 
+    @Transactional
     public LineResponse saveLine(LineRequest request) {
         Station upStation = stationRepository.findById(request.getUpStationId()).orElse(null);
         Station downStation = stationRepository.findById(request.getDownStationId()).orElse(null);
+
+        var section = Section.builder()
+            .upStation(upStation)
+            .downStation(downStation)
+            .distance(request.getDistance())
+            .build();
+
         Line line = lineRepository.save(Line.builder()
                 .name(request.getName())
                 .color(request.getColor())
-                .upStation(upStation)
-                .downStation(downStation)
-                .distance(request.getDistance())
+                .section(section)
                 .build());
 
-        return LineResponse.builder()
-                .id(line.getId())
-                .name(line.getName())
-                .color(line.getColor())
-                .stations(line.getStations())
-                .build();
+        return this.toLineResponse(line);
     }
 
-    public LineResponse findLine(Long id) {
-        return lineRepository.findById(id).map(o -> LineResponse.builder()
-                .id(o.getId())
-                .name(o.getName())
-                .color(o.getColor())
-                .stations(o.getStations())
-                .build())
-                .orElse(null);
+    public LineResponse findLineResponse(Long id) {
+        return this.toLineResponse(findLine(id));
+    }
+
+    public LineResponse toLineResponse(Line line) {
+        return LineResponse.builder()
+            .id(line.getId())
+            .name(line.getName())
+            .color(line.getColor())
+            .stations(line.getStations().stream()
+                .map(this::toStationResponse)
+                .collect(Collectors.toList()))
+            .build();
+    }
+
+    public StationResponse toStationResponse(Station station) {
+        return StationResponse.builder()
+            .id(station.getId())
+            .name(station.getName())
+            .build();
+    }
+    public Line findLine(Long id) {
+        return lineRepository.findById(id).orElseThrow(() -> new NoSuchElementException());
     }
 
     public List<LineResponse> findLines() {
-        return lineRepository.findAll().stream().map(o -> LineResponse.builder()
-                        .id(o.getId())
-                        .name(o.getName())
-                        .color(o.getColor())
-                        .stations(o.getStations())
-                        .build()).collect(Collectors.toList());
+        return lineRepository.findAll().stream()
+            .map(this::toLineResponse)
+            .collect(Collectors.toList());
     }
 
     @Transactional

--- a/src/main/java/subway/service/LineService.java
+++ b/src/main/java/subway/service/LineService.java
@@ -40,23 +40,13 @@ public class LineService {
                 .section(section)
                 .build());
 
-        return this.toLineResponse(line);
+        return LineResponse.from(line);
     }
 
     public LineResponse findLineResponse(Long id) {
-        return this.toLineResponse(findLine(id));
+        return LineResponse.from(findLine(id));
     }
 
-    public LineResponse toLineResponse(Line line) {
-        return LineResponse.builder()
-            .id(line.getId())
-            .name(line.getName())
-            .color(line.getColor())
-            .stations(line.getStations().stream()
-                .map(this::toStationResponse)
-                .collect(Collectors.toList()))
-            .build();
-    }
 
     public StationResponse toStationResponse(Station station) {
         return StationResponse.builder()
@@ -70,7 +60,7 @@ public class LineService {
 
     public List<LineResponse> findLines() {
         return lineRepository.findAll().stream()
-            .map(this::toLineResponse)
+            .map(LineResponse::from)
             .collect(Collectors.toList());
     }
 

--- a/src/main/java/subway/service/LineService.java
+++ b/src/main/java/subway/service/LineService.java
@@ -1,5 +1,7 @@
 package subway.service;
 
+import static subway.exception.ErrorCode.LINE_NOT_FOUND;
+
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -7,6 +9,7 @@ import subway.dto.response.StationResponse;
 import subway.entity.Line;
 import subway.entity.Section;
 import subway.entity.Station;
+import subway.exception.ApiException;
 import subway.repository.LineRepository;
 import subway.repository.StationRepository;
 import subway.dto.request.LineModifyRequest;
@@ -55,7 +58,7 @@ public class LineService {
             .build();
     }
     public Line findLine(Long id) {
-        return lineRepository.findById(id).orElseThrow(() -> new NoSuchElementException());
+        return lineRepository.findById(id).orElseThrow(() -> new ApiException(LINE_NOT_FOUND));
     }
 
     public List<LineResponse> findLines() {

--- a/src/main/java/subway/service/SectionService.java
+++ b/src/main/java/subway/service/SectionService.java
@@ -1,0 +1,37 @@
+package subway.service;
+
+import javax.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import subway.entity.Section;
+import subway.dto.request.SectionRequest;
+
+@Service
+@RequiredArgsConstructor
+public class SectionService {
+    private final LineService lineService;
+    private final StationService stationService;
+
+    @Transactional
+    public Section addSection(Long lineId, SectionRequest request) {
+        var sections = lineService.findLine(lineId).getSections();
+
+        var upStation = stationService.findStation(request.getUpStationId());
+        var downStation = stationService.findStation(request.getDownStationId());
+
+        sections.addSection(Section.builder()
+            .upStation(upStation)
+            .downStation(downStation)
+            .distance(request.getDistance())
+            .build());
+
+        return sections.lastSection();
+    }
+
+    @Transactional
+    public void deleteSection(Long lineId, Long stationId) {
+        var sections = lineService.findLine(lineId).getSections();
+
+        sections.deleteSection(stationId);
+    }
+}

--- a/src/main/java/subway/service/SectionService.java
+++ b/src/main/java/subway/service/SectionService.java
@@ -1,8 +1,10 @@
 package subway.service;
 
+import java.util.List;
 import javax.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import subway.dto.response.LineResponse;
 import subway.entity.Section;
 import subway.dto.request.SectionRequest;
 
@@ -13,19 +15,19 @@ public class SectionService {
     private final StationService stationService;
 
     @Transactional
-    public Section addSection(Long lineId, SectionRequest request) {
-        var sections = lineService.findLine(lineId).getSections();
+    public LineResponse addSection(Long lineId, SectionRequest request) {
+        var line = lineService.findLine(lineId);
 
         var upStation = stationService.findStation(request.getUpStationId());
         var downStation = stationService.findStation(request.getDownStationId());
 
-        sections.addSection(Section.builder()
+        line.getSections().addSection(Section.builder()
             .upStation(upStation)
             .downStation(downStation)
             .distance(request.getDistance())
             .build());
 
-        return sections.lastSection();
+        return LineResponse.from(line);
     }
 
     @Transactional

--- a/src/main/java/subway/service/StationService.java
+++ b/src/main/java/subway/service/StationService.java
@@ -1,9 +1,10 @@
 package subway.service;
 
+import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import subway.request.StationRequest;
-import subway.response.StationResponse;
+import subway.dto.request.StationRequest;
+import subway.dto.response.StationResponse;
 import subway.entity.Station;
 import subway.repository.StationRepository;
 
@@ -41,5 +42,9 @@ public class StationService {
                 station.getId(),
                 station.getName()
         );
+    }
+
+    public Station findStation(Long id) {
+        return stationRepository.findById(id).orElseThrow(() -> new NoSuchElementException());
     }
 }

--- a/src/main/java/subway/service/StationService.java
+++ b/src/main/java/subway/service/StationService.java
@@ -1,11 +1,15 @@
 package subway.service;
 
+import static subway.exception.ErrorCode.STATION_NOT_FOUND;
+
 import java.util.NoSuchElementException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import subway.dto.request.StationRequest;
 import subway.dto.response.StationResponse;
 import subway.entity.Station;
+import subway.exception.ApiException;
+import subway.exception.ErrorCode;
 import subway.repository.StationRepository;
 
 import java.util.List;
@@ -45,6 +49,6 @@ public class StationService {
     }
 
     public Station findStation(Long id) {
-        return stationRepository.findById(id).orElseThrow(() -> new NoSuchElementException());
+        return stationRepository.findById(id).orElseThrow(() -> new ApiException(STATION_NOT_FOUND));
     }
 }

--- a/src/test/java/subway/DatabaseCleanerTest.java
+++ b/src/test/java/subway/DatabaseCleanerTest.java
@@ -1,0 +1,24 @@
+package subway;
+
+import javax.persistence.EntityManager;
+import javax.persistence.metamodel.EntityType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+public class DatabaseCleanerTest {
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void entities() {
+        entityManager.getMetamodel()
+            .getEntities()
+            .stream()
+            .map(EntityType::getName)
+            .forEach(System.out::println);
+    }
+
+}

--- a/src/test/java/subway/LineAcceptanceTest.java
+++ b/src/test/java/subway/LineAcceptanceTest.java
@@ -11,16 +11,16 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-import subway.request.LineModifyRequest;
-import subway.request.LineRequest;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import subway.dto.request.LineModifyRequest;
+import subway.dto.request.LineRequest;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.springframework.test.annotation.DirtiesContext.MethodMode.AFTER_METHOD;
-
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @DisplayName("지하철 노선 관련 기능")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class LineAcceptanceTest {
 
     @LocalServerPort
@@ -48,19 +48,19 @@ public class LineAcceptanceTest {
      * When 지하철 노선을 생성하면
      * Then 지하철 노선 목록 조회 시 생성한 노선을 찾을 수 있다
      */
-    @DirtiesContext(methodMode = AFTER_METHOD)
+
     @DisplayName("지하철노선을 생성한다.")
     @Test
     void createLineAndFindList() {
         //when
-        LineRequest request = getLineRequest1();
+        LineRequest request = mockRequest_신분당선();
         this.createLine(request);
         //then
         List<String> names = this.findLines().jsonPath().getList("name", String.class);
         Assertions.assertThat(names).contains(request.getName());
     }
 
-    private static ExtractableResponse<Response> createLine(LineRequest dto) {
+    public static ExtractableResponse<Response> createLine(LineRequest dto) {
         return RestAssured.given().log().all()
                 .body(dto)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -82,13 +82,12 @@ public class LineAcceptanceTest {
      * When 지하철 노선 목록을 조회하면
      * Then 지하철 노선 목록 조회 시 2개의 노선을 조회할 수 있다.있다
      */
-    @DirtiesContext(methodMode = AFTER_METHOD)
     @DisplayName("지하철노선 목록을 조회한다.")
     @Test
     void create2LineAndFindLines() {
         //when
-        this.createLine(getLineRequest1());
-        this.createLine(getLineRequest2());
+        this.createLine(mockRequest_신분당선());
+        this.createLine(mockRequest_분당선());
 
         //then
         List<String> names = this.findLines().jsonPath().getList("name", String.class);
@@ -100,12 +99,11 @@ public class LineAcceptanceTest {
      * When 생성한 지하철 노선을 조회하면
      * Then 생성한 지하철 노선의 정보를 응답받을 수 있다.
      */
-    @DirtiesContext(methodMode = AFTER_METHOD)
     @DisplayName("지하철노선 목록을 조회한다.")
     @Test
     void create2LineAndfindLine() {
         //when
-        LineRequest request = getLineRequest1();
+        LineRequest request = mockRequest_신분당선();
         Long id = this.createLine(request).jsonPath().getLong("id");
 
         //then
@@ -114,7 +112,7 @@ public class LineAcceptanceTest {
     }
 
 
-    private static ExtractableResponse<Response> findLine(Long id) {
+    public static ExtractableResponse<Response> findLine(Long id) {
         return RestAssured.given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/lines/{id}", id)
@@ -127,12 +125,11 @@ public class LineAcceptanceTest {
      * When 생성한 지하철 노선을 수정하면
      * Then 해당 지하철 노선 정보는 수정된다
      */
-    @DirtiesContext(methodMode = AFTER_METHOD)
     @DisplayName("지하철노선을 수정한다.")
     @Test
     void createLineAndModifyLine() {
         //given
-        LineRequest request = getLineRequest1();
+        LineRequest request = mockRequest_신분당선();
         Long id = this.createLine(request).jsonPath().getLong("id");
 
         //when
@@ -162,12 +159,11 @@ public class LineAcceptanceTest {
      * When 생성한 지하철 노선을 삭제하면
      * Then 해당 지하철 노선 정보는 삭제된다
      */
-    @DirtiesContext(methodMode = AFTER_METHOD)
     @DisplayName("지하철노선을 삭제한다.")
     @Test
     void createLineAndDeleteLine() {
         //when
-        LineRequest request = getLineRequest1();
+        LineRequest request = mockRequest_신분당선();
         Long id = this.createLine(request).jsonPath().getLong("id");
 
         deleteLine(id);
@@ -185,7 +181,7 @@ public class LineAcceptanceTest {
                 .extract();
     }
 
-    private LineRequest getLineRequest1() {
+    private LineRequest mockRequest_신분당선() {
         String 신분당선 = "신분당선";
         return LineRequest.builder()
                 .name(신분당선)
@@ -196,7 +192,7 @@ public class LineAcceptanceTest {
                 .build();
     }
 
-    private LineRequest getLineRequest2() {
+    private LineRequest mockRequest_분당선() {
         String 분당선 = "분당선";
         return LineRequest.builder()
                 .name(분당선)

--- a/src/test/java/subway/SectionAcceptanceTest.java
+++ b/src/test/java/subway/SectionAcceptanceTest.java
@@ -1,0 +1,247 @@
+package subway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import subway.common.DatabaseCleaner;
+import subway.dto.request.LineRequest;
+
+@DisplayName("지하철 구간 관련 기능")
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+public class SectionAcceptanceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    DatabaseCleaner databaseCleaner;
+
+    Long lineId;
+
+    Map<String, Long> stationMaps = new HashMap<>();
+
+    @BeforeEach
+    void setUp() {
+        RestAssured.port = port;
+        databaseCleaner.execute();
+
+        createFixtureData();
+    }
+
+    void createFixtureData() {
+        //역 생성
+        Long 신논현역 = createStation("신논현역");
+        Long 강남역 = createStation("강남역");
+        Long 양재역 = createStation("양재역");
+
+        //라인 생성(신논현 - 강남)
+        ExtractableResponse<Response> response = LineAcceptanceTest.createLine(LineRequest.builder()
+            .name("신분당선")
+            .color("bg-red-600")
+            .upStationId(신논현역)
+            .downStationId(강남역)
+            .distance(10L)
+            .build());
+
+        lineId = response.jsonPath().getLong("id");
+
+        //구간 추가(강남 - 양재)
+        this.createSection(강남역, 양재역, 10);
+    }
+
+    Long createStation(String name) {
+        Long id = StationAcceptanceTest.createStation(name).jsonPath().getLong("id");
+        stationMaps.put(name, id);
+        return id;
+    }
+
+
+    /**
+     * POST /lines/1/sections
+     *
+     * @return
+     */
+    ExtractableResponse<Response> createSection(Long upStationId, Long downStationId, Integer distance) {
+        Map<String ,String> params = new HashMap<>();
+        params.put("upStationId", upStationId.toString());
+        params.put("downStationId", downStationId.toString());
+        params.put("distance", distance.toString());
+
+        return RestAssured.given().log().all()
+            .body(params)
+            .pathParam("lineId", lineId)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/lines/{lineId}/sections")
+            .then().log().all()
+            .extract();
+    }
+
+    /**
+     * When 지하철 구간을 생성하면
+     * Then 지하철 구간이 생성된다
+     * Then 지하철 라인 역 목록 조회 시 추가 한 구간의 종점 역을 찾을 수 있다.
+     */
+    @DisplayName("지하철 구간을 생성한다.")
+    @Test
+    void createSection() {
+        Long 양재역 = stationMaps.get("양재역");
+        Long 양재시민의숲역 = createStation("양재시민의숲역");
+
+        // when
+        ExtractableResponse<Response> response = this.createSection(양재역, 양재시민의숲역, 10);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+
+        // then
+        List<String> stations = LineAcceptanceTest.findLine(lineId).jsonPath()
+            .getList("stations.name", String.class);
+        assertThat(stations).containsAnyOf("양재시민의숲역");
+    }
+
+    /**
+     * When 하행 역으로 시작하지 않는 지하철 구간을 생성하면
+     * Then 지하철 구간이 생성되지 않는다.
+     */
+    @DisplayName("지하철 구간 생성 실패 - 등록되어 있는 하행 종점역이랑 다를경우")
+    @Test
+    void failToCreateSectionByDownStationId() {
+        Long 신사역 = createStation("신사역");
+        Long 논현역 = createStation("논현역");
+
+        // when
+        ExtractableResponse<Response> response = this.createSection(신사역, 논현역, 10);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * When 하행 역으로 시작하지 않는 지하철 구간을 생성하면
+     * Then 지하철 구간이 생성되지 않는다.
+     */
+    @DisplayName("지하철 구간 생성 실패 - 새로운 구간의 하행역은 해당 노선에 등록되어있는 역일 수 없다.")
+    @Test
+    void failToCreateSectionByExistStationId() {
+        Long 강남역 = stationMaps.get("강남역");
+        Long 양재역 = stationMaps.get("양재역");
+
+        // when
+        ExtractableResponse<Response> response = this.createSection(강남역, 양재역, 10);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    /**
+     * DELETE /lines/1/sections?stationId=2
+     *
+     * @return
+     */
+    ExtractableResponse<Response> deleteSection(Long stationId) {
+
+        return RestAssured.given().log().all()
+            .pathParam("lineId", lineId)
+            .queryParam("stationId", stationId)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().delete("/lines/{lineId}/sections")
+            .then().log().all()
+            .extract();
+    }
+
+    /**
+     * Given 2개 구간을 가지고 있는 라인을 생성한다.
+     * When 마지막 구간에 속한 역아이디로 삭제 요청을 한다.
+     * Then 지하철 구간이 삭제된다.
+     * Then 1개 구간 -> 2개의 station 만 존재함.
+     */
+    @DisplayName("지하철 구간을 삭제한다.")
+    @Test
+    void deleteSection() {
+        //given
+        Long 양재역 = stationMaps.get("양재역");
+
+        // when
+        ExtractableResponse<Response> response = this.deleteSection(양재역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+        assertThat(getStations()).hasSize(2);
+    }
+
+    /**
+     * Given 라인에 등록되지 않은 역을 생성한다
+     * When 라인에 등록되지 않은 역 아이디로 삭제를 요청한다
+     * Then 지하철 구간이 삭제되지 않는다.
+     */
+    @DisplayName("지하철 구간 삭제 실패 - 새로운 구간 제거시 위 조건에 부합하지 않는 경우 에러 처리한다.")
+    @Test
+    void deleteSectionByNotExistStationId() {
+        //given
+        Long 시청역 = createStation("시청역");
+
+        // when
+        ExtractableResponse<Response> response = this.deleteSection(시청역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(getStations()).hasSize(3);
+    }
+
+    private List<String> getStations() {
+        List<String> stations = LineAcceptanceTest.findLine(lineId).jsonPath().getList("stations");
+        return stations;
+    }
+
+    /**
+     * When 첫번째 구간에 포함된 역 아이디로 삭제를 요청한다
+     * Then 지하철 구간이 삭제되지 않는다.
+     */
+    @DisplayName("지하철 구간 삭제 실패 - 마지막 구간이 아닌 역으로는 삭제할 수 없다.")
+    @Test
+    void deleteSectionByUpStationId() {
+        //given
+        Long 강남역 = stationMaps.get("강남역");
+
+        // when
+        ExtractableResponse<Response> response = this.deleteSection(강남역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(getStations()).hasSize(3);
+    }
+
+    /**
+     * When 구간이 하나만 있는 하행 역 아이디로 삭제를 요청한다
+     * Then 지하철 구간이 삭제되지 않는다.
+     */
+    @DisplayName("지하철 구간 삭제 실패 - 지하철 노선에 상행 종점역과 하행 종점역만 있는 경우(구간이 1개인 경우) 역을 삭제할 수 없다.")
+    @Test
+    void deleteOnlyOneSection() {
+        //given
+        Long 강남역 = stationMaps.get("강남역");
+        Long 양재역 = stationMaps.get("양재역");
+        // given 구간 한개로
+        this.deleteSection(양재역);
+
+        // then
+        ExtractableResponse<Response> response = this.deleteSection(강남역);
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+        assertThat(getStations()).hasSize(2);
+    }
+}

--- a/src/test/java/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/subway/acceptance/LineAcceptanceTest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.acceptance;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -17,6 +17,8 @@ import subway.dto.request.LineRequest;
 
 import java.util.ArrayList;
 import java.util.List;
+import subway.fixture.LineFixture;
+import subway.fixture.StationFixture;
 
 @DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
 @DisplayName("지하철 노선 관련 기능")
@@ -35,9 +37,9 @@ public class LineAcceptanceTest {
     }
 
     private static void addStationCache() {
-        Long id1 = StationAcceptanceTest.createStation("지하철역").jsonPath().getLong("id");
-        Long id2 = StationAcceptanceTest.createStation("새로운지하철역").jsonPath().getLong("id");
-        Long id3 = StationAcceptanceTest.createStation("또다른지하철역").jsonPath().getLong("id");
+        Long id1 = StationFixture.createStation("지하철역").jsonPath().getLong("id");
+        Long id2 = StationFixture.createStation("새로운지하철역").jsonPath().getLong("id");
+        Long id3 = StationFixture.createStation("또다른지하철역").jsonPath().getLong("id");
 
         stationIds.add(id1);
         stationIds.add(id2);
@@ -54,19 +56,10 @@ public class LineAcceptanceTest {
     void createLineAndFindList() {
         //when
         LineRequest request = mockRequest_신분당선();
-        this.createLine(request);
+        LineFixture.createLine(request);
         //then
         List<String> names = this.findLines().jsonPath().getList("name", String.class);
         Assertions.assertThat(names).contains(request.getName());
-    }
-
-    public static ExtractableResponse<Response> createLine(LineRequest dto) {
-        return RestAssured.given().log().all()
-                .body(dto)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/lines")
-                .then().log().all()
-                .extract();
     }
 
     private static ExtractableResponse<Response> findLines() {
@@ -86,8 +79,8 @@ public class LineAcceptanceTest {
     @Test
     void create2LineAndFindLines() {
         //when
-        this.createLine(mockRequest_신분당선());
-        this.createLine(mockRequest_분당선());
+        LineFixture.createLine(mockRequest_신분당선());
+        LineFixture.createLine(mockRequest_분당선());
 
         //then
         List<String> names = this.findLines().jsonPath().getList("name", String.class);
@@ -104,21 +97,13 @@ public class LineAcceptanceTest {
     void create2LineAndfindLine() {
         //when
         LineRequest request = mockRequest_신분당선();
-        Long id = this.createLine(request).jsonPath().getLong("id");
+        Long id = LineFixture.createLine(request).jsonPath().getLong("id");
 
         //then
-        String name = this.findLine(id).jsonPath().get("name");
+        String name = LineFixture.findLine(id).jsonPath().get("name");
         Assertions.assertThat(name).isEqualTo(request.getName());
     }
 
-
-    public static ExtractableResponse<Response> findLine(Long id) {
-        return RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/lines/{id}", id)
-                .then().log().all()
-                .extract();
-    }
 
     /**
      * Given 지하철 노선을 생성하고
@@ -130,7 +115,7 @@ public class LineAcceptanceTest {
     void createLineAndModifyLine() {
         //given
         LineRequest request = mockRequest_신분당선();
-        Long id = this.createLine(request).jsonPath().getLong("id");
+        Long id = LineFixture.createLine(request).jsonPath().getLong("id");
 
         //when
         LineModifyRequest modify = LineModifyRequest.builder()
@@ -138,20 +123,11 @@ public class LineAcceptanceTest {
                 .color("bg-red-600")
                 .build();
 
-        this.modifyLine(id, modify);
+        LineFixture.modifyLine(id, modify);
 
         //then
-        String name = findLine(id).jsonPath().get("name");
+        String name = LineFixture.findLine(id).jsonPath().get("name");
         Assertions.assertThat(name).isEqualTo(modify.getName());
-    }
-
-    private static ExtractableResponse<Response> modifyLine(Long id, LineModifyRequest request) {
-        return RestAssured.given()
-                .body(request).log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().put("/lines/{id}", id)
-                .then().log().all()
-                .extract();
     }
 
     /**
@@ -164,7 +140,7 @@ public class LineAcceptanceTest {
     void createLineAndDeleteLine() {
         //when
         LineRequest request = mockRequest_신분당선();
-        Long id = this.createLine(request).jsonPath().getLong("id");
+        Long id = LineFixture.createLine(request).jsonPath().getLong("id");
 
         deleteLine(id);
 

--- a/src/test/java/subway/acceptance/StationAcceptanceTest.java
+++ b/src/test/java/subway/acceptance/StationAcceptanceTest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.acceptance;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import subway.fixture.StationFixture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +42,7 @@ public class StationAcceptanceTest {
         String 강남역 = "강남역";
         params.put("name", 강남역);
 
-        ExtractableResponse<Response> response = this.createStation(강남역);
+        ExtractableResponse<Response> response = StationFixture.createStation(강남역);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -63,26 +63,14 @@ public class StationAcceptanceTest {
         //given
         String 강남역 = "강남역";
         String 양재역 = "양재역";
-        this.createStation(강남역);
-        this.createStation(양재역);
+        StationFixture.createStation(강남역);
+        StationFixture.createStation(양재역);
 
         //when
         List<String> stationNames = this.getStationNames();
 
         //then
         assertThat(stationNames).containsAnyOf(강남역, 양재역);
-    }
-
-    public static ExtractableResponse<Response> createStation(String name) {
-        Map<String ,String> params = new HashMap<>();
-        params.put("name", name);
-
-        return RestAssured.given().log().all()
-                .body(params)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/stations")
-                .then().log().all()
-                .extract();
     }
 
 
@@ -96,10 +84,10 @@ public class StationAcceptanceTest {
     void deleteStation() {
         //given
         String 강남역 = "강남역";
-        Long id = this.createStation(강남역).jsonPath().getLong("id");
+        Long id = StationFixture.createStation(강남역).jsonPath().getLong("id");
 
         //when
-        this.deleteStation(id);
+        StationFixture.deleteStation(id);
         List<String> stationNames = this.getStationNames();
 
         //then
@@ -115,11 +103,4 @@ public class StationAcceptanceTest {
         return stationNames;
     }
 
-    private ExtractableResponse<Response> deleteStation(Long id) {
-        return RestAssured.given().log().all()
-            .contentType(MediaType.APPLICATION_JSON_VALUE)
-            .when().delete("/stations/{id}", id)
-            .then().log().all()
-            .extract();
-    }
 }

--- a/src/test/java/subway/common/DatabaseCleanerTest.java
+++ b/src/test/java/subway/common/DatabaseCleanerTest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.common;
 
 import javax.persistence.EntityManager;
 import javax.persistence.metamodel.EntityType;

--- a/src/test/java/subway/common/RestAssuredTest.java
+++ b/src/test/java/subway/common/RestAssuredTest.java
@@ -1,4 +1,4 @@
-package subway;
+package subway.common;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;

--- a/src/test/java/subway/fixture/LineFixture.java
+++ b/src/test/java/subway/fixture/LineFixture.java
@@ -1,0 +1,37 @@
+package subway.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+import subway.dto.request.LineModifyRequest;
+import subway.dto.request.LineRequest;
+
+public class LineFixture {
+    public static ExtractableResponse<Response> createLine(LineRequest dto) {
+        return RestAssured.given().log().all()
+            .body(dto)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/lines")
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> findLine(Long id) {
+        return RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().get("/lines/{id}", id)
+            .then().log().all()
+            .extract();
+    }
+
+    public static ExtractableResponse<Response> modifyLine(Long id, LineModifyRequest request) {
+        return RestAssured.given()
+            .body(request).log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().put("/lines/{id}", id)
+            .then().log().all()
+            .extract();
+    }
+
+}

--- a/src/test/java/subway/fixture/SectionFixture.java
+++ b/src/test/java/subway/fixture/SectionFixture.java
@@ -1,0 +1,48 @@
+package subway.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.MediaType;
+
+public class SectionFixture {
+
+
+    /**
+     * POST /lines/1/sections
+     *
+     * @return
+     */
+    public static ExtractableResponse<Response> createSection(Long lineId, Long upStationId, Long downStationId, Integer distance) {
+        Map<String ,String> params = new HashMap<>();
+        params.put("upStationId", upStationId.toString());
+        params.put("downStationId", downStationId.toString());
+        params.put("distance", distance.toString());
+
+        return RestAssured.given().log().all()
+            .body(params)
+            .pathParam("lineId", lineId)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/lines/{lineId}/sections")
+            .then().log().all()
+            .extract();
+    }
+
+    /**
+     * DELETE /lines/1/sections?stationId=2
+     *
+     * @return
+     */
+    public static ExtractableResponse<Response> deleteSection(Long lineId, Long stationId) {
+
+        return RestAssured.given().log().all()
+            .pathParam("lineId", lineId)
+            .queryParam("stationId", stationId)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().delete("/lines/{lineId}/sections")
+            .then().log().all()
+            .extract();
+    }
+}

--- a/src/test/java/subway/fixture/StationFixture.java
+++ b/src/test/java/subway/fixture/StationFixture.java
@@ -1,0 +1,32 @@
+package subway.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.MediaType;
+
+public class StationFixture {
+    public static ExtractableResponse<Response> createStation(String name) {
+        Map<String ,String> params = new HashMap<>();
+        params.put("name", name);
+
+        return RestAssured.given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/stations")
+            .then().log().all()
+            .extract();
+    }
+
+
+    public static ExtractableResponse<Response> deleteStation(Long id) {
+        return RestAssured.given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().delete("/stations/{id}", id)
+            .then().log().all()
+            .extract();
+    }
+
+}


### PR DESCRIPTION
지하철 구간 추가 기능 개선 구현
* 기존 : 구간은 종점에서만 추가 가능
* 변경 : 구간은 앞, 뒤, 중간 모두 추가 가능
- [x] : 새로운 역을 상행 종점으로 등록
- [x] : 새로운 역을 하행 종점으로 등록
- [x] : 역 사이에 새로운 역을 등록
* 예외 조건
- [x] : 역 사이에 새로운 역을 등록할 경우, 거리는 기존의 구간보다 짧아야 함
- [x] : 상행역과 하행역이 이미 노선에 모두 등록되어 있다면 추가할 수 없음
- [x] : 상행역과 하행역 둘 중 하나도 포함되어있지 않으면 추가할 수 없음

리뷰 잘부탁드립니다 :)