### PR TITLE
🚀 1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -63,13 +63,13 @@ public class StationAcceptanceTest {
     @Test
     void getStationsSuccess() {
         // given
-        var createdStations = List.of(
+        final var createdStations = List.of(
             this.createStation("선릉역"),
             this.createStation("청계산입구역")
         );
 
         // when
-        var response = RestAssured
+        final var response = RestAssured
             .given().log().all()
             .contentType(MediaType.APPLICATION_JSON_VALUE)
             .when().get("/stations")
@@ -80,11 +80,12 @@ public class StationAcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
 
         // then
-        assertThat(response.jsonPath().getList("id", Long.class)).containsAll(
-            createdStations.stream()
-                .map(StationResponse::getId)
-                .collect(Collectors.toList())
-        );
+        assertThat(response.jsonPath().getList("id", Long.class))
+            .containsAll(
+                createdStations.stream()
+                    .map(StationResponse::getId)
+                    .collect(Collectors.toList())
+            );
     }
 
     /**
@@ -96,7 +97,7 @@ public class StationAcceptanceTest {
     @Test
     void deleteStationSuccess() {
         // given
-        var deletedStation = this.createStation("삼성역");
+        final var deletedStation = this.createStation("삼성역");
 
         // when
         RestAssured
@@ -106,7 +107,7 @@ public class StationAcceptanceTest {
             .then().log().all()
             .extract();
 
-        var responseStations = getStations();
+        final var responseStations = getStations();
 
         // then
         assertThat(responseStations.stream()

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -3,6 +3,8 @@ package subway;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DisplayName("지하철역 관련 기능")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class StationAcceptanceTest {
+
     /**
      * When 지하철역을 생성하면
      * Then 지하철역이 생성된다
@@ -25,28 +28,29 @@ public class StationAcceptanceTest {
      */
     @DisplayName("지하철역을 생성한다.")
     @Test
-    void createStation() {
+    void createStationSuccess() {
         // when
         Map<String, String> params = new HashMap<>();
         params.put("name", "강남역");
 
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = RestAssured
+            .given().log().all()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/stations")
+            .then().log().all()
+            .extract();
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
+        List<String> stationNames = RestAssured
+            .given().log().all()
+            .when().get("/stations")
+            .then().log().all()
+            .extract().jsonPath().getList("name", String.class);
+
         assertThat(stationNames).containsAnyOf("강남역");
     }
 
@@ -55,13 +59,80 @@ public class StationAcceptanceTest {
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 조회한다.")
+    @Test
+    void getStationsSuccess() {
+        // given
+        var createdStations = List.of(
+            this.createStation("선릉역"),
+            this.createStation("청계산입구역")
+        );
+
+        // when
+        var response = RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().get("/stations")
+            .then().log().all()
+            .extract();
+
+        // then
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+
+        // then
+        assertThat(response.jsonPath().getList("id", Long.class)).containsAll(
+            createdStations.stream()
+                .map(StationResponse::getId)
+                .collect(Collectors.toList())
+        );
+    }
 
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 삭제한다.")
+    @Test
+    void deleteStationSuccess() {
+        // given
+        var deletedStation = this.createStation("삼성역");
+
+        // when
+        RestAssured
+            .given().log().all()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().delete("/stations/{id}", deletedStation.getId())
+            .then().log().all()
+            .extract();
+
+        var responseStations = getStations();
+
+        // then
+        assertThat(responseStations.stream()
+            .filter(responseStation -> deletedStation.getId().equals(responseStation.getId()))
+            .findAny()
+            .isEmpty()
+        ).isTrue();
+    }
+
+    private StationResponse createStation(final String stationName) {
+        return RestAssured
+            .given()
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(Map.of("name", stationName))
+            .when().post("/stations")
+            .then().extract().as(StationResponse.class);
+    }
+
+    private List<StationResponse> getStations() {
+        return Arrays.asList(
+            RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/stations")
+                .then().extract().as(StationResponse[].class)
+        );
+    }
 
 }


### PR DESCRIPTION
### 작업 내용
* 지하철역 목록 조회 인수 테스트 작성
* 지하철역 삭제 인수 테스트 작성

### 피드백 받고 싶은 내용
* `StationResponse` DTO의 equals 메소드를 재정의하면 아래 테스트 코드를 좀 더 깔끔하게 만들 수 있겠다는 생각을 했습니다. 이것에 대해 어떻게 생각하시는지 혹은 재정의 하는게 괜찮을 것 같다면 id 필드를 포함시킬지 말지에 대해 준우님 의견이 궁금합니다!
``` java
        assertThat(response.jsonPath().getList("id", Long.class)).containsAll(
            createdStations.stream()
                .map(StationResponse::getId)
                .collect(Collectors.toList())
        );
```
* 제가 작성한 테스트 코드의 가독성과 관련해서 피드백을 받고 싶습니다. 신랄하게 까주시면 감사하겠습니다 🥲 