### PR TITLE
1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,12 @@ group = 'nextstep'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '11'
 
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
 repositories {
     mavenCentral()
 }
@@ -19,6 +25,11 @@ dependencies {
 
     // log
     implementation 'net.rakugakibox.spring.boot:logback-access-spring-boot-starter:2.7.1'
+
+    implementation 'com.google.guava:guava:33.2.1-jre'
+
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:4.5.1'

--- a/src/test/java/subway/StationAcceptanceSteps.java
+++ b/src/test/java/subway/StationAcceptanceSteps.java
@@ -48,6 +48,11 @@ public class StationAcceptanceSteps {
     assertThat(stationNames).containsExactlyInAnyOrder(names);
   }
 
+  public static void 지하철역_목록에_포함되지_않음(ExtractableResponse<Response> response, String... names) {
+    List<String> stationNames = response.jsonPath().getList("name", String.class);
+    assertThat(stationNames).doesNotContain(names).isEmpty();
+  }
+
   public static ExtractableResponse<Response> 지하철역_삭제_요청(String uri) {
     return RestAssured.given().log().all()
         .when().delete(uri)

--- a/src/test/java/subway/StationAcceptanceSteps.java
+++ b/src/test/java/subway/StationAcceptanceSteps.java
@@ -1,0 +1,55 @@
+package subway;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StationAcceptanceSteps {
+  private StationAcceptanceSteps() {
+  }
+
+  public static ExtractableResponse<Response> 지하철역_생성_요청(String name) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", name);
+
+    return RestAssured.given().log().all()
+        .body(params)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when().post("/stations")
+        .then().log().all()
+        .extract();
+  }
+
+  public static void 지하철역_생성됨(ExtractableResponse<Response> response) {
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+  }
+
+  public static ExtractableResponse<Response> 지하철역_목록_조회_요청() {
+    return RestAssured.given().log().all()
+        .when().get("/stations")
+        .then().log().all()
+        .extract();
+  }
+
+  public static void 지하철역_목록_조회됨(ExtractableResponse<Response> response) {
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  public static ExtractableResponse<Response> 지하철역_삭제_요청(String uri) {
+    return RestAssured.given().log().all()
+        .when().delete(uri)
+        .then().log().all()
+        .extract();
+  }
+
+  public static void 지하철역_삭제됨(ExtractableResponse<Response> response) {
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+  }
+}

--- a/src/test/java/subway/StationAcceptanceSteps.java
+++ b/src/test/java/subway/StationAcceptanceSteps.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +41,11 @@ public class StationAcceptanceSteps {
 
   public static void 지하철역_목록_조회됨(ExtractableResponse<Response> response) {
     assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+  }
+
+  public static void 지하철역_목록에_포함됨(ExtractableResponse<Response> response, String... names) {
+    List<String> stationNames = response.jsonPath().getList("name", String.class);
+    assertThat(stationNames).containsExactlyInAnyOrder(names);
   }
 
   public static ExtractableResponse<Response> 지하철역_삭제_요청(String uri) {

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -7,9 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import subway.support.AcceptanceTest;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 import static subway.StationAcceptanceSteps.*;
 
 @DisplayName("지하철역 관련 기능")
@@ -63,8 +60,6 @@ class StationAcceptanceTest extends AcceptanceTest {
     ExtractableResponse<Response> response = 지하철역_삭제_요청(uri);
 
     지하철역_삭제됨(response);
-    ExtractableResponse<Response> stationsResponse = 지하철역_목록_조회_요청();
-    List<String> stationNames = stationsResponse.jsonPath().getList("name", String.class);
-    assertThat(stationNames).doesNotContain("강남역").isEmpty();
+    지하철역_목록에_포함되지_않음(지하철역_목록_조회_요청(), "강남역");
   }
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -1,6 +1,5 @@
 package subway;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -30,12 +29,7 @@ class StationAcceptanceTest extends AcceptanceTest {
     지하철역_생성됨(response);
 
     // then
-    List<String> stationNames =
-        RestAssured.given().log().all()
-            .when().get("/stations")
-            .then().log().all()
-            .extract().jsonPath().getList("name", String.class);
-    assertThat(stationNames).containsAnyOf("강남역");
+    지하철역_목록에_포함됨(지하철역_목록_조회_요청(), "강남역");
   }
 
   /**
@@ -52,12 +46,8 @@ class StationAcceptanceTest extends AcceptanceTest {
     ExtractableResponse<Response> response = 지하철역_목록_조회_요청();
 
     지하철역_목록_조회됨(response);
-
-    List<String> stationNames = response.jsonPath().getList("name", String.class);
-    assertThat(stationNames).containsExactlyInAnyOrder("강남역", "역삼역");
+    지하철역_목록에_포함됨(response, "강남역", "역삼역");
   }
-
-
 
   /**
    * Given 지하철역을 생성하고
@@ -73,7 +63,6 @@ class StationAcceptanceTest extends AcceptanceTest {
     ExtractableResponse<Response> response = 지하철역_삭제_요청(uri);
 
     지하철역_삭제됨(response);
-
     ExtractableResponse<Response> stationsResponse = 지하철역_목록_조회_요청();
     List<String> stationNames = stationsResponse.jsonPath().getList("name", String.class);
     assertThat(stationNames).doesNotContain("강남역").isEmpty();

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -5,9 +5,9 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import subway.support.AcceptanceTest;
 
 import java.util.HashMap;
 import java.util.List;
@@ -16,52 +16,68 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철역 관련 기능")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class StationAcceptanceTest {
-    /**
-     * When 지하철역을 생성하면
-     * Then 지하철역이 생성된다
-     * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
-     */
-    @DisplayName("지하철역을 생성한다.")
-    @Test
-    void createStation() {
-        // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
+class StationAcceptanceTest extends AcceptanceTest {
+  /**
+   * When 지하철역을 생성하면
+   * Then 지하철역이 생성된다
+   * Then 지하철역 목록 조회 시 생성한 역을 찾을 수 있다
+   */
+  @DisplayName("지하철역을 생성한다.")
+  @Test
+  void createStation() {
+    // when
+    ExtractableResponse<Response> response = givenStationCreated("강남역");
 
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    // then
+    List<String> stationNames =
+        RestAssured.given().log().all()
+            .when().get("/stations")
+            .then().log().all()
+            .extract().jsonPath().getList("name", String.class);
+    assertThat(stationNames).containsAnyOf("강남역");
+  }
 
-        // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
-        assertThat(stationNames).containsAnyOf("강남역");
-    }
+  /**
+   * Given 2개의 지하철역을 생성하고
+   * When 지하철역 목록을 조회하면
+   * Then 2개의 지하철역을 응답 받는다
+   */
+  @DisplayName("지하철역 목록을 조회한다.")
+  @Test
+  void showStations() {
+    givenStationCreated("강남역");
+    givenStationCreated("역삼역");
 
-    /**
-     * Given 2개의 지하철역을 생성하고
-     * When 지하철역 목록을 조회하면
-     * Then 2개의 지하철역을 응답 받는다
-     */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    ExtractableResponse<Response> response = RestAssured.given().log().all()
+        .when().get("/stations")
+        .then().log().all()
+        .extract();
 
-    /**
-     * Given 지하철역을 생성하고
-     * When 그 지하철역을 삭제하면
-     * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
-     */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
 
+    List<String> stationNames = response.jsonPath().getList("name", String.class);
+    assertThat(stationNames).containsExactlyInAnyOrder("강남역", "역삼역");
+  }
+
+  /**
+   * Given 지하철역을 생성하고
+   * When 그 지하철역을 삭제하면
+   * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
+   */
+  // TODO: 지하철역 제거 인수 테스트 메서드 생성
+
+  private static ExtractableResponse<Response> givenStationCreated(String name) {
+    Map<String, String> params = new HashMap<>();
+    params.put("name", name);
+
+    return RestAssured.given().log().all()
+        .body(params)
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .when().post("/stations")
+        .then().log().all()
+        .extract();
+  }
 }

--- a/src/test/java/subway/support/AcceptanceTest.java
+++ b/src/test/java/subway/support/AcceptanceTest.java
@@ -1,0 +1,29 @@
+package subway.support;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestConstructor;
+
+@ActiveProfiles("test")
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class AcceptanceTest {
+  @LocalServerPort
+  int port;
+  
+  @Autowired
+  private DatabaseCleanup databaseCleanup;
+
+  @BeforeEach
+  void setUp() {
+    if (RestAssured.port == RestAssured.UNDEFINED_PORT) {
+      RestAssured.port = port;
+      databaseCleanup.afterPropertiesSet();
+    }
+    databaseCleanup.execute();
+  }
+}

--- a/src/test/java/subway/support/DatabaseCleanup.java
+++ b/src/test/java/subway/support/DatabaseCleanup.java
@@ -1,0 +1,43 @@
+package subway.support;
+
+import com.google.common.base.CaseFormat;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.Entity;
+import javax.persistence.EntityManager;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@ActiveProfiles("test")
+public class DatabaseCleanup implements InitializingBean {
+  @Autowired
+  private EntityManager entityManager;
+
+  private List<String> tableNames;
+
+  @Override
+  public void afterPropertiesSet() {
+    tableNames = entityManager.getMetamodel().getEntities().stream()
+        .filter(e -> e.getJavaType().getAnnotation(Entity.class) != null)
+        .map(e -> CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, e.getName()))
+        .collect(Collectors.toUnmodifiableList());
+  }
+
+  @Transactional
+  public void execute() {
+    entityManager.flush();
+    entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY FALSE").executeUpdate();
+
+    for (String tableName : tableNames) {
+      entityManager.createNativeQuery("TRUNCATE TABLE " + tableName).executeUpdate();
+      entityManager.createNativeQuery("ALTER TABLE " + tableName + " ALTER COLUMN ID RESTART WITH 1").executeUpdate();
+    }
+
+    entityManager.createNativeQuery("SET REFERENTIAL_INTEGRITY TRUE").executeUpdate();
+  }
+}


### PR DESCRIPTION
- 인수 테스트 메서드가 유저 스토리로 읽혀지도록 편의 메서드를 추가했습니다.
- 각 메서드 실행 전에 데이터베이스를 초기화 하도록 `AcceptanceTest`라는 추상 클래스를 추가했습니다.
- Lombok을 dependencies에 추가했습니다.