### PR TITLE
🚀 1단계 - 지하철역 인수 테스트 작성

### DIFF
--- a/src/test/java/subway/RestAssuredTest.java
+++ b/src/test/java/subway/RestAssuredTest.java
@@ -1,23 +1,19 @@
 package subway;
 
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
+import io.restassured.RestAssured;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 public class RestAssuredTest {
 
     @DisplayName("구글 페이지 접근 테스트")
     @Test
     void accessGoogle() {
-        // TODO: 구글 페이지 요청 구현
-        ExtractableResponse<Response> response = null;
-
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+        RestAssured
+                .given()
+                .when()
+                    .get("https://google.com")
+                .then()
+                    .statusCode(200);
     }
 }

--- a/src/test/java/subway/StationAcceptanceTest.java
+++ b/src/test/java/subway/StationAcceptanceTest.java
@@ -27,41 +27,86 @@ public class StationAcceptanceTest {
     @Test
     void createStation() {
         // when
-        Map<String, String> params = new HashMap<>();
-        params.put("name", "강남역");
-
-        ExtractableResponse<Response> response =
-                RestAssured.given().log().all()
-                        .body(params)
-                        .contentType(MediaType.APPLICATION_JSON_VALUE)
-                        .when().post("/stations")
-                        .then().log().all()
-                        .extract();
+        ExtractableResponse<Response> response = createStation("강남역");
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
 
         // then
-        List<String> stationNames =
-                RestAssured.given().log().all()
-                        .when().get("/stations")
-                        .then().log().all()
-                        .extract().jsonPath().getList("name", String.class);
+        List<String> stationNames = findAllStations();
+
         assertThat(stationNames).containsAnyOf("강남역");
     }
+
 
     /**
      * Given 2개의 지하철역을 생성하고
      * When 지하철역 목록을 조회하면
      * Then 2개의 지하철역을 응답 받는다
      */
-    // TODO: 지하철역 목록 조회 인수 테스트 메서드 생성
+    @DisplayName("지하철역 목록을 조회한다.")
+    @Test
+    void retrieveStation() {
+        // given
+        createStation("강남역");
+        createStation("을지로4가역");
+
+        // when
+        List<String> stationNames = findAllStations();
+
+        // then
+        assertThat(stationNames)
+                .contains("강남역", "을지로4가역");
+        assertThat(stationNames.size()).isEqualTo(2);
+    }
+
 
     /**
      * Given 지하철역을 생성하고
      * When 그 지하철역을 삭제하면
      * Then 그 지하철역 목록 조회 시 생성한 역을 찾을 수 없다
      */
-    // TODO: 지하철역 제거 인수 테스트 메서드 생성
+    @DisplayName("지하철역을 삭제한다.")
+    @Test
+    void deleteStation() {
+        // given
+        createStation("강남역");
+        ExtractableResponse<Response> response = createStation("을지로4가역");
 
+        String createdStationId = response.body().jsonPath().getString("id");
+
+        // when
+        deleteStation(createdStationId);
+        List<String> stationNames = findAllStations();
+
+        // then
+        assertThat(stationNames).contains("강남역");
+        assertThat(stationNames).doesNotContain("을지로4가역");
+        assertThat(stationNames.size()).isEqualTo(1);
+    }
+
+    private ExtractableResponse<Response> createStation(String stationName) {
+        Map<String, String> params = new HashMap<>();
+        params.put("name", stationName);
+
+        return RestAssured.given().log().all()
+                .body(params)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/stations")
+                .then().log().all()
+                .extract();
+    }
+
+    private List<String> findAllStations() {
+        return RestAssured.given().log().all()
+                .when().get("/stations")
+                .then().log().all()
+                .extract().jsonPath().getList("name", String.class);
+    }
+
+    private void deleteStation(String stationId) {
+        RestAssured.given().log().all()
+                .when().delete("/stations/" + stationId)
+                .then().log().all();
+    }
 }


### PR DESCRIPTION
1단계 미션 관련해서 테스트를 추가해 보았습니다. RestAssured 를 사용하여 테스트 코드를 작성하는 것이 아직은 어색한 것 같네요.

### 변경 요약
- 조회와 삭제 관련 테스트를 given, when, then 시나리오에 맞추어 작성 했습니다
- 관련하여 반복적으로 등장하는 지하철역 생성, 조회, 삭제 부분을 private method로 추출하였습니다.

### 고민이 된 부분
-  기존에 작성되어 있는 테스트는@DisplayName 이 "지하철역을 생성한다" 인데, 이렇게 작성하는 것이 좀 어색하게 느껴집니다. 
   - "지하철 생성 테스트", "지하철 생성 API 테스트" 정도로 명명 했을 것 같은데, "지하철역을 생성한다"가 테스트 명칭인 것은 인수테스트가 유저스토리를 기반으로 하기 때문이라고 이해하면 되는 걸까요?

